### PR TITLE
chore: release v0.1.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,17 +113,19 @@ jobs:
       fail-fast: false
       matrix:
         platform:
-          - macos-arm64
+          - macos-latest
           - macos-x64
           - windows-x64
-
         include:
-          - platform: macos-arm64
+          - platform: macos-latest
             os: macos-14
+            args: "--target aarch64-apple-darwin"
           - platform: macos-x64
             os: macos-13
+            args: "--target x86_64-apple-darwin"
           - platform: windows-x64
             os: windows-2022
+            args: ""
 
     steps:
       - name: Checkout source code
@@ -134,30 +136,15 @@ jobs:
         with:
           toolchain: stable
           targets: wasm32-unknown-unknown
-
-      # - name: Install tauri cli
-      #   run: |
-      #     cargo install tauri-cli --version "^2.0.0" --locked
+      - uses: cargo-bins/cargo-binstall@main
 
       - name: Install trunk
         run: |
-          cargo install --locked trunk
+          cargo binstall --locked trunk
 
-      # - name: Create dist directory
-      #   shell: bash
-      #   run: mkdir -p ./dist
-      - name: Build
+      - name: build-tauri
         uses: tauri-apps/tauri-action@v0
         env:
-          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
-      # - name: Build
-      #   env:
-      #     CARGO_TERM_COLOR: always
-      #     GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
-      #     RUST_BACKTRACE: 1
-      #     RUST_LOG: "info"
-      #     RUST_LOG_SPAN_EVENTS: full
-      #     RUSTFLAGS: -Cinstrument-coverage
-      #     RUSTDOCFLAGS: -Cinstrument-coverage
-      #   run: |
-      #     cargo tauri build
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          args: ${{ matrix.args }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,65 @@
+name: release-bundles
+
+permissions:
+  contents: write
+
+on:
+  release:
+    types: [published]
+
+env:
+  CARGO_INCREMENTAL: 0
+  CARGO_NET_GIT_FETCH_WITH_CLI: true
+  CARGO_NET_RETRY: 10
+  CARGO_TERM_COLOR: always
+  RUST_BACKTRACE: 1
+  RUSTFLAGS: -D warnings
+  RUSTUP_MAX_RETRIES: 10
+
+jobs:
+  build-tauri-app:
+    name: release-app-${{ matrix.platform }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        platform:
+          - macos-latest
+          - macos-x64
+          - windows-x64
+        include:
+          - platform: macos-latest
+            os: macos-14
+            args: "--target aarch64-apple-darwin"
+          - platform: macos-x64
+            os: macos-13
+            args: "--target x86_64-apple-darwin"
+          - platform: windows-x64
+            os: windows-2022
+            args: ""
+
+    steps:
+      - name: Checkout source code
+        uses: actions/checkout@v4
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: stable
+          targets: wasm32-unknown-unknown
+
+      - name: Install trunk
+        run: |
+          cargo install --locked trunk
+
+      - name: build-tauri
+        uses: tauri-apps/tauri-action@v0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tagName: arenabuddy-v__VERSION__
+          releaseName: "Arenabuddy v__VERSION__"
+          releaseBody: "See the assets to download this version and install."
+          releaseDraft: true
+          prerelease: false
+          args: ${{ matrix.args }}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,6 @@ keywords.workspace = true
 license.workspace = true
 
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [dependencies]
 arenabuddy_core = { path = "arenabuddy_core/", version = "0.1.0" }
 leptos = { workspace = true, features = ["csr"] }

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -8,21 +8,26 @@ publish_timeout = "10m"       # set a timeout for `cargo publish`
 name = "arenabuddy"
 publish = false
 release = false
+git_release_enable = false
 
 [[package]]
 name = "arenabuddy_core"
 publish = true
+git_release_enable = false
 
 [[package]]
 name = "arenabuddy_cli"
 publish = true
+git_release_enable = false
 
 [[package]]
 name = "arenabuddy_scraper"
 publish = false
 release = false
+git_release_enable = false
 
 [[package]]
 name = "arenabuddy_ui"
 publish = false
 release = false
+git_release_enable = false

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "arenabuddy",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "identifier": "com.gazure.dev.arenabuddy.app",
   "build": {
     "beforeDevCommand": "trunk serve",


### PR DESCRIPTION



## 🤖 New release

* `arenabuddy_core`: 0.1.1
* `arenabuddy_cli`: 0.1.1

<details><summary><i><b>Changelog</b></i></summary><p>

## `arenabuddy_core`

<blockquote>

## [0.1.1](https://github.com/gazure/arenabuddy/compare/arenabuddy_core-v0.1.0...arenabuddy_core-v0.1.1) - 2025-02-02

### Other

- trying to get the leptos front-end to work ([#9](https://github.com/gazure/arenabuddy/pull/9))
</blockquote>

## `arenabuddy_cli`

<blockquote>

## [0.1.0](https://github.com/gazure/arenabuddy/releases/tag/arenabuddy_cli-v0.1.0) - 2025-01-28

### Other

- remove editor config ([#2](https://github.com/gazure/arenabuddy/pull/2))
- Initial commit, porting from arena-parser, arenaparser
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).