### PR TITLE
chore: release v0.2.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ license.workspace = true
 
 
 [dependencies]
-arenabuddy_core = { path = "arenabuddy_core/", version = "0.1.3" }
+arenabuddy_core = { path = "arenabuddy_core/", version = "0.2.0" }
 leptos = { workspace = true, features = ["csr"] }
 wasm-bindgen = { workspace = true }
 wasm-bindgen-futures = { workspace = true }
@@ -33,7 +33,7 @@ members = [
 [workspace.package]
 authors = ["Grant Azure <azure.grant@gmail.com>"]
 categories = []
-version = "0.1.3"
+version = "0.2.0"
 repository = "https://github.com/gazure/arenabuddy"
 edition = "2021"
 keywords = ["magic"]

--- a/arenabuddy_cli/CHANGELOG.md
+++ b/arenabuddy_cli/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.0](https://github.com/gazure/arenabuddy/compare/arenabuddy_cli-v0.1.3...arenabuddy_cli-v0.2.0) - 2025-02-09
+
+### Added
+
+- simple refactors (#17)
+
 ## [0.1.0](https://github.com/gazure/arenabuddy/releases/tag/arenabuddy_cli-v0.1.0) - 2025-01-28
 
 ### Other

--- a/arenabuddy_cli/Cargo.toml
+++ b/arenabuddy_cli/Cargo.toml
@@ -19,7 +19,7 @@ serde_json = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
 rusqlite = { workspace = true, features = ["bundled"] }
-arenabuddy_core = { path = "../arenabuddy_core", version = "0.1.3" }
+arenabuddy_core = { path = "../arenabuddy_core", version = "0.2.0" }
 
 [[bin]]
 name = "arenaparser"

--- a/arenabuddy_core/CHANGELOG.md
+++ b/arenabuddy_core/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.0](https://github.com/gazure/arenabuddy/compare/arenabuddy_core-v0.1.3...arenabuddy_core-v0.2.0) - 2025-02-09
+
+### Added
+
+- simple refactors (#17)
+
 ## [0.1.3](https://github.com/gazure/arenabuddy/compare/arenabuddy_core-v0.1.2...arenabuddy_core-v0.1.3) - 2025-02-08
 
 ### Added

--- a/arenabuddy_scraper/Cargo.toml
+++ b/arenabuddy_scraper/Cargo.toml
@@ -13,7 +13,7 @@ license.workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-arenabuddy_core = { path = "../arenabuddy_core", version = "0.1.3" }
+arenabuddy_core = { path = "../arenabuddy_core", version = "0.2.0" }
 anyhow = { workspace = true }
 csv = { workspace = true }
 reqwest = { workspace = true, features = ["json"] }

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -6,7 +6,7 @@ publish_timeout = "10m"
 
 [[package]]
 name = "arenabuddy"
-publish = false
+publish = true
 release = true
 git_release_enable = true
 

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -22,7 +22,7 @@ crate-type = ["staticlib", "cdylib", "rlib"]
 tauri-build = { workspace = true, features = [] }
 
 [dependencies]
-arenabuddy_core = { path = "../arenabuddy_core", version = "0.1.3" }
+arenabuddy_core = { path = "../arenabuddy_core", version = "0.2.0" }
 tauri = { workspace = true, features = [] }
 tauri-plugin-opener.workspace = true
 serde = { workspace = true, features = ["derive"] }

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "arenabuddy",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "identifier": "com.gazure.dev.arenabuddy.app",
   "build": {
     "beforeDevCommand": "trunk serve",


### PR DESCRIPTION



## 🤖 New release

* `arenabuddy`: 0.2.0
* `arenabuddy_core`: 0.2.0
* `arenabuddy_cli`: 0.2.0

<details><summary><i><b>Changelog</b></i></summary><p>

## `arenabuddy`

<blockquote>

## [0.1.2](https://github.com/gazure/arenabuddy/compare/arenabuddy-v0.1.1...arenabuddy-v0.1.2) - 2025-02-08

### Other

- release v0.1.1 (#11)
- release v0.1.1 (#10)
- trying to get the leptos front-end to work ([#9](https://github.com/gazure/arenabuddy/pull/9))
- release v0.1.0 (#4)
- updating CI and finishing scraper ([#3](https://github.com/gazure/arenabuddy/pull/3))
- remove editor config ([#2](https://github.com/gazure/arenabuddy/pull/2))
- Initial commit, porting from arena-parser, arenaparser
</blockquote>

## `arenabuddy_core`

<blockquote>

## [0.2.0](https://github.com/gazure/arenabuddy/compare/arenabuddy_core-v0.1.3...arenabuddy_core-v0.2.0) - 2025-02-09

### Added

- simple refactors (#17)
</blockquote>

## `arenabuddy_cli`

<blockquote>

## [0.2.0](https://github.com/gazure/arenabuddy/compare/arenabuddy_cli-v0.1.3...arenabuddy_cli-v0.2.0) - 2025-02-09

### Added

- simple refactors (#17)
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).