### PR TITLE
chore: release v0.3.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ license.workspace = true
 
 
 [dependencies]
-arenabuddy_core = { path = "arenabuddy_core/", version = "0.2.3" }
+arenabuddy_core = { path = "arenabuddy_core/", version = "0.3.0" }
 leptos = { workspace = true, features = ["csr"] }
 wasm-bindgen = { workspace = true }
 wasm-bindgen-futures = { workspace = true }
@@ -34,7 +34,7 @@ members = [
 [workspace.package]
 authors = ["Grant Azure <azure.grant@gmail.com>"]
 categories = []
-version = "0.2.3"
+version = "0.3.0"
 repository = "https://github.com/gazure/arenabuddy"
 edition = "2024"
 keywords = ["magic"]

--- a/arenabuddy_cli/CHANGELOG.md
+++ b/arenabuddy_cli/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.0](https://github.com/gazure/arenabuddy/compare/arenabuddy_cli-v0.2.3...arenabuddy_cli-v0.3.0) - 2025-02-21
+
+### Added
+
+- 2024 edition, rename MatchDb (#25)
+
 ## [0.2.0](https://github.com/gazure/arenabuddy/compare/arenabuddy_cli-v0.1.3...arenabuddy_cli-v0.2.0) - 2025-02-09
 
 ### Added

--- a/arenabuddy_cli/Cargo.toml
+++ b/arenabuddy_cli/Cargo.toml
@@ -19,7 +19,7 @@ serde_json = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
 rusqlite = { workspace = true, features = ["bundled"] }
-arenabuddy_core = { path = "../arenabuddy_core", version = "0.2.3" }
+arenabuddy_core = { path = "../arenabuddy_core", version = "0.3.0" }
 
 [[bin]]
 name = "arenaparser"

--- a/arenabuddy_core/CHANGELOG.md
+++ b/arenabuddy_core/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.0](https://github.com/gazure/arenabuddy/compare/arenabuddy_core-v0.2.3...arenabuddy_core-v0.3.0) - 2025-02-21
+
+### Added
+
+- 2024 edition, rename MatchDb (#25)
+
 ## [0.2.3](https://github.com/gazure/arenabuddy/compare/arenabuddy_core-v0.2.2...arenabuddy_core-v0.2.3) - 2025-02-19
 
 ### Added

--- a/arenabuddy_scraper/Cargo.toml
+++ b/arenabuddy_scraper/Cargo.toml
@@ -13,7 +13,7 @@ license.workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-arenabuddy_core = { path = "../arenabuddy_core", version = "0.2.3" }
+arenabuddy_core = { path = "../arenabuddy_core", version = "0.3.0" }
 anyhow = { workspace = true }
 csv = { workspace = true }
 reqwest = { workspace = true, features = ["json"] }

--- a/src-tauri/CHANGELOG.md
+++ b/src-tauri/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.0](https://github.com/gazure/arenabuddy/compare/arenabuddy-v0.2.3...arenabuddy-v0.3.0) - 2025-02-21
+
+### Added
+
+- 2024 edition, rename MatchDb (#25)
+
 ## [0.2.3](https://github.com/gazure/arenabuddy/compare/arenabuddy-v0.2.2...arenabuddy-v0.2.3) - 2025-02-19
 
 ### Added

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -22,7 +22,7 @@ crate-type = ["staticlib", "cdylib", "rlib"]
 tauri-build = { workspace = true, features = [] }
 
 [dependencies]
-arenabuddy_core = { path = "../arenabuddy_core", version = "0.2.3" }
+arenabuddy_core = { path = "../arenabuddy_core", version = "0.3.0" }
 tauri = { workspace = true, features = [] }
 tauri-plugin-opener.workspace = true
 serde = { workspace = true, features = ["derive"] }


### PR DESCRIPTION



## 🤖 New release

* `arenabuddy`: 0.2.3 -> 0.3.0
* `arenabuddy_core`: 0.2.3 -> 0.3.0 (⚠ API breaking changes)
* `arenabuddy_cli`: 0.2.3 -> 0.3.0

### ⚠ `arenabuddy_core` breaking changes

```text
--- failure struct_missing: pub struct removed or renamed ---

Description:
A publicly-visible struct cannot be imported by its prior path. A `pub use` may have been removed, or the struct itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.39.0/src/lints/struct_missing.ron

Failed in:
  struct arenabuddy_core::match_insights::MatchInsightDB, previously in file /tmp/.tmp87RV6h/arenabuddy_core/src/match_insights.rs:26
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `arenabuddy`

<blockquote>

## [0.3.0](https://github.com/gazure/arenabuddy/compare/arenabuddy-v0.2.3...arenabuddy-v0.3.0) - 2025-02-21

### Added

- 2024 edition, rename MatchDb (#25)
</blockquote>

## `arenabuddy_core`

<blockquote>

## [0.3.0](https://github.com/gazure/arenabuddy/compare/arenabuddy_core-v0.2.3...arenabuddy_core-v0.3.0) - 2025-02-21

### Added

- 2024 edition, rename MatchDb (#25)
</blockquote>

## `arenabuddy_cli`

<blockquote>

## [0.3.0](https://github.com/gazure/arenabuddy/compare/arenabuddy_cli-v0.2.3...arenabuddy_cli-v0.3.0) - 2025-02-21

### Added

- 2024 edition, rename MatchDb (#25)
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).