### PR TITLE
chore: release v0.3.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ license.workspace = true
 
 
 [dependencies]
-arenabuddy_core = { path = "arenabuddy_core/", version = "0.3.1" }
+arenabuddy_core = { path = "arenabuddy_core/", version = "0.3.2" }
 leptos = { workspace = true, features = ["csr"] }
 wasm-bindgen = { workspace = true }
 wasm-bindgen-futures = { workspace = true }
@@ -34,7 +34,7 @@ members = [
 [workspace.package]
 authors = ["Grant Azure <azure.grant@gmail.com>"]
 categories = []
-version = "0.3.1"
+version = "0.3.2"
 repository = "https://github.com/gazure/arenabuddy"
 edition = "2024"
 keywords = ["magic"]

--- a/arenabuddy_cli/Cargo.toml
+++ b/arenabuddy_cli/Cargo.toml
@@ -19,7 +19,7 @@ serde_json = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
 rusqlite = { workspace = true, features = ["bundled"] }
-arenabuddy_core = { path = "../arenabuddy_core", version = "0.3.1" }
+arenabuddy_core = { path = "../arenabuddy_core", version = "0.3.2" }
 
 [[bin]]
 name = "arenaparser"

--- a/arenabuddy_scraper/Cargo.toml
+++ b/arenabuddy_scraper/Cargo.toml
@@ -13,7 +13,7 @@ license.workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-arenabuddy_core = { path = "../arenabuddy_core", version = "0.3.1" }
+arenabuddy_core = { path = "../arenabuddy_core", version = "0.3.2" }
 anyhow = { workspace = true }
 csv = { workspace = true }
 reqwest = { workspace = true, features = ["json"] }

--- a/src-tauri/CHANGELOG.md
+++ b/src-tauri/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.2](https://github.com/gazure/arenabuddy/compare/arenabuddy-v0.3.1...arenabuddy-v0.3.2) - 2025-02-26
+
+### Added
+
+- error logs page (#30)
+
 ## [0.3.1](https://github.com/gazure/arenabuddy/compare/arenabuddy-v0.3.0...arenabuddy-v0.3.1) - 2025-02-22
 
 ### Fixed

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -22,7 +22,7 @@ crate-type = ["staticlib", "cdylib", "rlib"]
 tauri-build = { workspace = true, features = [] }
 
 [dependencies]
-arenabuddy_core = { path = "../arenabuddy_core", version = "0.3.1" }
+arenabuddy_core = { path = "../arenabuddy_core", version = "0.3.2" }
 tauri = { workspace = true, features = [] }
 tauri-plugin-opener.workspace = true
 serde = { workspace = true, features = ["derive"] }


### PR DESCRIPTION



## 🤖 New release

* `arenabuddy_core`: 0.3.1 -> 0.3.2
* `arenabuddy`: 0.3.1 -> 0.3.2
* `arenabuddy_cli`: 0.3.1 -> 0.3.2

<details><summary><i><b>Changelog</b></i></summary><p>

## `arenabuddy_core`

<blockquote>

## [0.3.1](https://github.com/gazure/arenabuddy/compare/arenabuddy_core-v0.3.0...arenabuddy_core-v0.3.1) - 2025-02-22

### Fixed

- fix matchdb indocs, ad-hoc signing identity (#27)
</blockquote>

## `arenabuddy`

<blockquote>

## [0.3.2](https://github.com/gazure/arenabuddy/compare/arenabuddy-v0.3.1...arenabuddy-v0.3.2) - 2025-02-26

### Added

- error logs page (#30)
</blockquote>

## `arenabuddy_cli`

<blockquote>

## [0.3.0](https://github.com/gazure/arenabuddy/compare/arenabuddy_cli-v0.2.3...arenabuddy_cli-v0.3.0) - 2025-02-21

### Added

- 2024 edition, rename MatchDb (#25)
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).