### PR TITLE
chore: release v0.3.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -137,7 +137,7 @@ checksum = "dcfed56ad506cb2c684a14971b8861fdc3baaaae314b9e5f9bb532cbe3ba7a4f"
 
 [[package]]
 name = "arenabuddy"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "anyhow",
  "arenabuddy_core",
@@ -160,7 +160,7 @@ dependencies = [
 
 [[package]]
 name = "arenabuddy_cli"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "anyhow",
  "arenabuddy_core",
@@ -176,7 +176,7 @@ dependencies = [
 
 [[package]]
 name = "arenabuddy_core"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "anyhow",
  "chrono",
@@ -194,7 +194,7 @@ dependencies = [
 
 [[package]]
 name = "arenabuddy_scraper"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "anyhow",
  "arenabuddy_core",
@@ -209,7 +209,7 @@ dependencies = [
 
 [[package]]
 name = "arenabuddy_ui"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "arenabuddy_core",
  "console_error_panic_hook",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ license.workspace = true
 
 
 [dependencies]
-arenabuddy_core = { path = "arenabuddy_core/", version = "0.3.2" }
+arenabuddy_core = { path = "arenabuddy_core/", version = "0.3.3" }
 leptos = { workspace = true, features = ["csr"] }
 wasm-bindgen = { workspace = true }
 wasm-bindgen-futures = { workspace = true }
@@ -34,7 +34,7 @@ members = [
 [workspace.package]
 authors = ["Grant Azure <azure.grant@gmail.com>"]
 categories = []
-version = "0.3.2"
+version = "0.3.3"
 repository = "https://github.com/gazure/arenabuddy"
 edition = "2024"
 keywords = ["magic"]

--- a/arenabuddy_cli/CHANGELOG.md
+++ b/arenabuddy_cli/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.3](https://github.com/gazure/arenabuddy/compare/arenabuddy_cli-v0.3.2...arenabuddy_cli-v0.3.3) - 2025-03-30
+
+### Other
+
+- update Cargo.toml dependencies
+
 ## [0.3.0](https://github.com/gazure/arenabuddy/compare/arenabuddy_cli-v0.2.3...arenabuddy_cli-v0.3.0) - 2025-02-21
 
 ### Added

--- a/arenabuddy_cli/Cargo.toml
+++ b/arenabuddy_cli/Cargo.toml
@@ -19,7 +19,7 @@ serde_json = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
 rusqlite = { workspace = true, features = ["bundled"] }
-arenabuddy_core = { path = "../arenabuddy_core", version = "0.3.2" }
+arenabuddy_core = { path = "../arenabuddy_core", version = "0.3.3" }
 
 [[bin]]
 name = "arenaparser"

--- a/arenabuddy_core/CHANGELOG.md
+++ b/arenabuddy_core/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.3](https://github.com/gazure/arenabuddy/compare/arenabuddy_core-v0.3.2...arenabuddy_core-v0.3.3) - 2025-03-30
+
+### Other
+
+- update Cargo.toml dependencies
+
 ## [0.3.1](https://github.com/gazure/arenabuddy/compare/arenabuddy_core-v0.3.0...arenabuddy_core-v0.3.1) - 2025-02-22
 
 ### Fixed

--- a/arenabuddy_scraper/Cargo.toml
+++ b/arenabuddy_scraper/Cargo.toml
@@ -13,7 +13,7 @@ license.workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-arenabuddy_core = { path = "../arenabuddy_core", version = "0.3.2" }
+arenabuddy_core = { path = "../arenabuddy_core", version = "0.3.3" }
 anyhow = { workspace = true }
 csv = { workspace = true }
 reqwest = { workspace = true, features = ["json"] }

--- a/src-tauri/CHANGELOG.md
+++ b/src-tauri/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.3](https://github.com/gazure/arenabuddy/compare/arenabuddy-v0.3.2...arenabuddy-v0.3.3) - 2025-03-30
+
+### Other
+
+- update Cargo.toml dependencies
+
 ## [0.3.2](https://github.com/gazure/arenabuddy/compare/arenabuddy-v0.3.1...arenabuddy-v0.3.2) - 2025-02-26
 
 ### Added

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -22,7 +22,7 @@ crate-type = ["staticlib", "cdylib", "rlib"]
 tauri-build = { workspace = true, features = [] }
 
 [dependencies]
-arenabuddy_core = { path = "../arenabuddy_core", version = "0.3.2" }
+arenabuddy_core = { path = "../arenabuddy_core", version = "0.3.3" }
 tauri = { workspace = true, features = [] }
 tauri-plugin-opener.workspace = true
 serde = { workspace = true, features = ["derive"] }


### PR DESCRIPTION



## 🤖 New release

* `arenabuddy_core`: 0.3.2 -> 0.3.3 (✓ API compatible changes)
* `arenabuddy`: 0.3.2 -> 0.3.3
* `arenabuddy_cli`: 0.3.2 -> 0.3.3

<details><summary><i><b>Changelog</b></i></summary><p>

## `arenabuddy_core`

<blockquote>

## [0.3.3](https://github.com/gazure/arenabuddy/compare/arenabuddy_core-v0.3.2...arenabuddy_core-v0.3.3) - 2025-03-30

### Other

- update Cargo.toml dependencies
</blockquote>

## `arenabuddy`

<blockquote>

## [0.3.3](https://github.com/gazure/arenabuddy/compare/arenabuddy-v0.3.2...arenabuddy-v0.3.3) - 2025-03-30

### Other

- update Cargo.toml dependencies
</blockquote>

## `arenabuddy_cli`

<blockquote>

## [0.3.3](https://github.com/gazure/arenabuddy/compare/arenabuddy_cli-v0.3.2...arenabuddy_cli-v0.3.3) - 2025-03-30

### Other

- update Cargo.toml dependencies
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).