### PR TITLE
chore: release v0.4.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -137,7 +137,7 @@ checksum = "e16d2d3311acee920a9eb8d33b8cbc1787ce4a264e85f964c2404b969bdcd487"
 
 [[package]]
 name = "arenabuddy"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "anyhow",
  "arenabuddy_core",
@@ -160,7 +160,7 @@ dependencies = [
 
 [[package]]
 name = "arenabuddy_cli"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "anyhow",
  "arenabuddy_core",
@@ -176,7 +176,7 @@ dependencies = [
 
 [[package]]
 name = "arenabuddy_core"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "anyhow",
  "chrono",
@@ -194,7 +194,7 @@ dependencies = [
 
 [[package]]
 name = "arenabuddy_scraper"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "anyhow",
  "arenabuddy_core",
@@ -209,7 +209,7 @@ dependencies = [
 
 [[package]]
 name = "arenabuddy_ui"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "arenabuddy_core",
  "console_error_panic_hook",
@@ -1990,9 +1990,9 @@ checksum = "17e2ac29387b1aa07a1e448f7bb4f35b500787971e965b02842b900afa5c8f6f"
 
 [[package]]
 name = "h2"
-version = "0.4.8"
+version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5017294ff4bb30944501348f6f8e42e6ad28f42c8bbef7a74029aff064a4e3c2"
+checksum = "75249d144030531f8dee69fe9cea04d3edf809a017ae445e2abdff6629e86633"
 dependencies = [
  "atomic-waker",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ license.workspace = true
 
 
 [dependencies]
-arenabuddy_core = { path = "arenabuddy_core/", version = "0.4.0" }
+arenabuddy_core = { path = "arenabuddy_core/", version = "0.4.1" }
 leptos = { workspace = true, features = ["csr"] }
 wasm-bindgen = { workspace = true }
 wasm-bindgen-futures = { workspace = true }
@@ -34,7 +34,7 @@ members = [
 [workspace.package]
 authors = ["Grant Azure <azure.grant@gmail.com>"]
 categories = []
-version = "0.4.0"
+version = "0.4.1"
 repository = "https://github.com/gazure/arenabuddy"
 edition = "2024"
 rust-version = "1.86"

--- a/arenabuddy_cli/CHANGELOG.md
+++ b/arenabuddy_cli/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.1](https://github.com/gazure/arenabuddy/compare/arenabuddy_cli-v0.4.0...arenabuddy_cli-v0.4.1) - 2025-04-14
+
+### Other
+
+- update Cargo.toml dependencies
+
 ## [0.4.0](https://github.com/gazure/arenabuddy/compare/arenabuddy_cli-v0.3.4...arenabuddy_cli-v0.4.0) - 2025-04-12
 
 ### Other

--- a/arenabuddy_cli/Cargo.toml
+++ b/arenabuddy_cli/Cargo.toml
@@ -19,7 +19,7 @@ serde_json = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
 rusqlite = { workspace = true, features = ["bundled"] }
-arenabuddy_core = { path = "../arenabuddy_core", version = "0.4.0" }
+arenabuddy_core = { path = "../arenabuddy_core", version = "0.4.1" }
 
 [[bin]]
 name = "arenaparser"

--- a/arenabuddy_core/CHANGELOG.md
+++ b/arenabuddy_core/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.1](https://github.com/gazure/arenabuddy/compare/arenabuddy_core-v0.4.0...arenabuddy_core-v0.4.1) - 2025-04-14
+
+### Other
+
+- update Cargo.toml dependencies
+
 ## [0.4.0](https://github.com/gazure/arenabuddy/compare/arenabuddy_core-v0.3.4...arenabuddy_core-v0.4.0) - 2025-04-12
 
 ### Other

--- a/arenabuddy_scraper/Cargo.toml
+++ b/arenabuddy_scraper/Cargo.toml
@@ -13,7 +13,7 @@ license.workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-arenabuddy_core = { path = "../arenabuddy_core", version = "0.4.0" }
+arenabuddy_core = { path = "../arenabuddy_core", version = "0.4.1" }
 anyhow = { workspace = true }
 csv = { workspace = true }
 reqwest = { workspace = true, features = ["json", "stream"] }

--- a/src-tauri/CHANGELOG.md
+++ b/src-tauri/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.1](https://github.com/gazure/arenabuddy/compare/arenabuddy-v0.4.0...arenabuddy-v0.4.1) - 2025-04-14
+
+### Other
+
+- update Cargo.toml dependencies
+
 ## [0.4.0](https://github.com/gazure/arenabuddy/compare/arenabuddy-v0.3.4...arenabuddy-v0.4.0) - 2025-04-12
 
 ### Other

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -22,7 +22,7 @@ crate-type = ["staticlib", "cdylib", "rlib"]
 tauri-build = { workspace = true, features = [] }
 
 [dependencies]
-arenabuddy_core = { path = "../arenabuddy_core", version = "0.4.0" }
+arenabuddy_core = { path = "../arenabuddy_core", version = "0.4.1" }
 tauri = { workspace = true, features = [] }
 tauri-plugin-opener.workspace = true
 serde = { workspace = true, features = ["derive"] }


### PR DESCRIPTION



## 🤖 New release

* `arenabuddy_core`: 0.4.0 -> 0.4.1 (✓ API compatible changes)
* `arenabuddy`: 0.4.0 -> 0.4.1
* `arenabuddy_cli`: 0.4.0 -> 0.4.1

<details><summary><i><b>Changelog</b></i></summary><p>

## `arenabuddy_core`

<blockquote>

## [0.4.1](https://github.com/gazure/arenabuddy/compare/arenabuddy_core-v0.4.0...arenabuddy_core-v0.4.1) - 2025-04-14

### Other

- update Cargo.toml dependencies
</blockquote>

## `arenabuddy`

<blockquote>

## [0.4.1](https://github.com/gazure/arenabuddy/compare/arenabuddy-v0.4.0...arenabuddy-v0.4.1) - 2025-04-14

### Other

- update Cargo.toml dependencies
</blockquote>

## `arenabuddy_cli`

<blockquote>

## [0.4.1](https://github.com/gazure/arenabuddy/compare/arenabuddy_cli-v0.4.0...arenabuddy_cli-v0.4.1) - 2025-04-14

### Other

- update Cargo.toml dependencies
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).