### PR TITLE
chore: release v0.5.8

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -131,7 +131,7 @@ checksum = "e16d2d3311acee920a9eb8d33b8cbc1787ce4a264e85f964c2404b969bdcd487"
 
 [[package]]
 name = "arenabuddy"
-version = "0.5.7"
+version = "0.5.8"
 dependencies = [
  "anyhow",
  "arenabuddy_core",
@@ -156,7 +156,7 @@ dependencies = [
 
 [[package]]
 name = "arenabuddy_cli"
-version = "0.5.7"
+version = "0.5.8"
 dependencies = [
  "anyhow",
  "arenabuddy_core",
@@ -180,7 +180,7 @@ dependencies = [
 
 [[package]]
 name = "arenabuddy_core"
-version = "0.5.7"
+version = "0.5.8"
 dependencies = [
  "chrono",
  "derive_builder",
@@ -200,7 +200,7 @@ dependencies = [
 
 [[package]]
 name = "arenabuddy_data"
-version = "0.5.7"
+version = "0.5.8"
 dependencies = [
  "arenabuddy_core",
  "chrono",
@@ -215,7 +215,7 @@ dependencies = [
 
 [[package]]
 name = "arenabuddy_ui"
-version = "0.5.7"
+version = "0.5.8"
 dependencies = [
  "arenabuddy_core",
  "console_error_panic_hook",
@@ -537,9 +537,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-s3"
-version = "1.95.0"
+version = "1.96.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a316e3c4c38837084dfbf87c0fc6ea016b3dc3e1f867d9d7f5eddfe47e5cae37"
+checksum = "6e25d24de44b34dcdd5182ac4e4c6f07bcec2661c505acef94c0d293b65505fe"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -3285,6 +3285,17 @@ name = "interpolator"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71dd52191aae121e8611f1e8dc3e324dd0dd1dee1e6dd91d10ee07a3cfb4d9d8"
+
+[[package]]
+name = "io-uring"
+version = "0.7.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b86e202f00093dcba4275d4636b93ef9dd75d025ae560d2521b45ea28ab49013"
+dependencies = [
+ "bitflags 2.9.1",
+ "cfg-if",
+ "libc",
+]
 
 [[package]]
 name = "ipnet"
@@ -6808,17 +6819,19 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.45.1"
+version = "1.46.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75ef51a33ef1da925cea3e4eb122833cb377c61439ca401b770f54902b806779"
+checksum = "1140bb80481756a8cbe10541f37433b459c5aa1e727b4c020fbfebdc25bf3ec4"
 dependencies = [
  "backtrace",
  "bytes",
+ "io-uring",
  "libc",
  "mio",
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
+ "slab",
  "socket2",
  "tokio-macros",
  "tracing",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ license.workspace = true
 
 
 [dependencies]
-arenabuddy_core = { path = "arenabuddy_core/", version = "0.5.7" }
+arenabuddy_core = { path = "arenabuddy_core/", version = "0.5.8" }
 leptos = { workspace = true, features = ["csr"] }
 wasm-bindgen = { workspace = true }
 wasm-bindgen-futures = { workspace = true }
@@ -29,7 +29,7 @@ members = ["src-tauri", "arenabuddy_core", "arenabuddy_cli", "arenabuddy_data"]
 [workspace.package]
 authors = ["Grant Azure <azure.grant@gmail.com>"]
 categories = []
-version = "0.5.7"
+version = "0.5.8"
 repository = "https://github.com/gazure/arenabuddy"
 edition = "2024"
 rust-version = "1.88"

--- a/arenabuddy_cli/CHANGELOG.md
+++ b/arenabuddy_cli/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.8](https://github.com/gazure/arenabuddy/compare/arenabuddy_cli-v0.5.7...arenabuddy_cli-v0.5.8) - 2025-07-03
+
+### Added
+
+- move data out of core, reducing need for conditional compilation ([#85](https://github.com/gazure/arenabuddy/pull/85))
+
 ## [0.5.7](https://github.com/gazure/arenabuddy/compare/arenabuddy_cli-v0.5.6...arenabuddy_cli-v0.5.7) - 2025-07-02
 
 ### Fixed

--- a/arenabuddy_cli/Cargo.toml
+++ b/arenabuddy_cli/Cargo.toml
@@ -11,8 +11,8 @@ version.workspace = true
 
 [dependencies]
 anyhow = { workspace = true }
-arenabuddy_core = { path = "../arenabuddy_core", version = "0.5.7" }
-arenabuddy_data = { path = "../arenabuddy_data", version = "0.5.7" }
+arenabuddy_core = { path = "../arenabuddy_core", version = "0.5.8" }
+arenabuddy_data = { path = "../arenabuddy_data", version = "0.5.8" }
 aws-config = { workspace = true, features = ["behavior-version-latest"] }
 aws-sdk-s3 = { workspace = true }
 clap = { workspace = true }

--- a/arenabuddy_core/CHANGELOG.md
+++ b/arenabuddy_core/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.8](https://github.com/gazure/arenabuddy/compare/arenabuddy_core-v0.5.7...arenabuddy_core-v0.5.8) - 2025-07-03
+
+### Added
+
+- move data out of core, reducing need for conditional compilation ([#85](https://github.com/gazure/arenabuddy/pull/85))
+
 ## [0.5.7](https://github.com/gazure/arenabuddy/compare/arenabuddy_core-v0.5.6...arenabuddy_core-v0.5.7) - 2025-07-02
 
 ### Fixed

--- a/arenabuddy_data/CHANGELOG.md
+++ b/arenabuddy_data/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.5.8](https://github.com/gazure/arenabuddy/compare/arenabuddy_data-v0.5.7...arenabuddy_data-v0.5.8) - 2025-07-03
+
+### Added
+
+- move data out of core, reducing need for conditional compilation ([#85](https://github.com/gazure/arenabuddy/pull/85))

--- a/arenabuddy_data/Cargo.toml
+++ b/arenabuddy_data/Cargo.toml
@@ -10,7 +10,7 @@ keywords.workspace = true
 license.workspace = true
 
 [dependencies]
-arenabuddy_core = { path = "../arenabuddy_core/", version = "0.5.7" }
+arenabuddy_core = { path = "../arenabuddy_core/", version = "0.5.8" }
 chrono = { workspace = true, features = ["serde"] }
 include_dir = { workspace = true }
 indoc = { workspace = true }

--- a/src-tauri/CHANGELOG.md
+++ b/src-tauri/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.8](https://github.com/gazure/arenabuddy/compare/arenabuddy-v0.5.7...arenabuddy-v0.5.8) - 2025-07-03
+
+### Added
+
+- move data out of core, reducing need for conditional compilation ([#85](https://github.com/gazure/arenabuddy/pull/85))
+
 ## [0.5.7](https://github.com/gazure/arenabuddy/compare/arenabuddy-v0.5.6...arenabuddy-v0.5.7) - 2025-07-02
 
 ### Fixed

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -22,8 +22,8 @@ crate-type = ["staticlib", "cdylib", "rlib"]
 tauri-build = { version = "2", features = [] }
 
 [dependencies]
-arenabuddy_core = { path = "../arenabuddy_core", version = "0.5.7" }
-arenabuddy_data = { path = "../arenabuddy_data", version = "0.5.7" }
+arenabuddy_core = { path = "../arenabuddy_core", version = "0.5.8" }
+arenabuddy_data = { path = "../arenabuddy_data", version = "0.5.8" }
 tauri = { version = "2", features = [] }
 tauri-plugin-opener = "2"
 tauri-plugin-dialog = "2"


### PR DESCRIPTION



## 🤖 New release

* `arenabuddy_core`: 0.5.7 -> 0.5.8 (✓ API compatible changes)
* `arenabuddy_data`: 0.5.7 -> 0.5.8
* `arenabuddy`: 0.5.7 -> 0.5.8
* `arenabuddy_cli`: 0.5.7 -> 0.5.8

<details><summary><i><b>Changelog</b></i></summary><p>

## `arenabuddy_core`

<blockquote>

## [0.5.8](https://github.com/gazure/arenabuddy/compare/arenabuddy_core-v0.5.7...arenabuddy_core-v0.5.8) - 2025-07-03

### Added

- move data out of core, reducing need for conditional compilation ([#85](https://github.com/gazure/arenabuddy/pull/85))
</blockquote>

## `arenabuddy_data`

<blockquote>

## [0.5.8](https://github.com/gazure/arenabuddy/compare/arenabuddy_data-v0.5.7...arenabuddy_data-v0.5.8) - 2025-07-03

### Added

- move data out of core, reducing need for conditional compilation ([#85](https://github.com/gazure/arenabuddy/pull/85))
</blockquote>

## `arenabuddy`

<blockquote>

## [0.5.8](https://github.com/gazure/arenabuddy/compare/arenabuddy-v0.5.7...arenabuddy-v0.5.8) - 2025-07-03

### Added

- move data out of core, reducing need for conditional compilation ([#85](https://github.com/gazure/arenabuddy/pull/85))
</blockquote>

## `arenabuddy_cli`

<blockquote>

## [0.5.8](https://github.com/gazure/arenabuddy/compare/arenabuddy_cli-v0.5.7...arenabuddy_cli-v0.5.8) - 2025-07-03

### Added

- move data out of core, reducing need for conditional compilation ([#85](https://github.com/gazure/arenabuddy/pull/85))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).