### PR TITLE
chore: release v0.5.10

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -131,7 +131,7 @@ checksum = "e16d2d3311acee920a9eb8d33b8cbc1787ce4a264e85f964c2404b969bdcd487"
 
 [[package]]
 name = "arenabuddy"
-version = "0.5.9"
+version = "0.5.10"
 dependencies = [
  "anyhow",
  "arenabuddy_core",
@@ -156,7 +156,7 @@ dependencies = [
 
 [[package]]
 name = "arenabuddy_cli"
-version = "0.5.9"
+version = "0.5.10"
 dependencies = [
  "anyhow",
  "arenabuddy_core",
@@ -180,7 +180,7 @@ dependencies = [
 
 [[package]]
 name = "arenabuddy_core"
-version = "0.5.9"
+version = "0.5.10"
 dependencies = [
  "chrono",
  "derive_builder",
@@ -200,7 +200,7 @@ dependencies = [
 
 [[package]]
 name = "arenabuddy_data"
-version = "0.5.9"
+version = "0.5.10"
 dependencies = [
  "arenabuddy_core",
  "chrono",
@@ -215,7 +215,7 @@ dependencies = [
 
 [[package]]
 name = "arenabuddy_ui"
-version = "0.5.9"
+version = "0.5.10"
 dependencies = [
  "arenabuddy_core",
  "console_error_panic_hook",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ license.workspace = true
 
 
 [dependencies]
-arenabuddy_core = { path = "arenabuddy_core/", version = "0.5.9" }
+arenabuddy_core = { path = "arenabuddy_core/", version = "0.5.10" }
 leptos = { workspace = true, features = ["csr"] }
 wasm-bindgen = { workspace = true }
 wasm-bindgen-futures = { workspace = true }
@@ -29,7 +29,7 @@ members = ["src-tauri", "arenabuddy_core", "arenabuddy_cli", "arenabuddy_data"]
 [workspace.package]
 authors = ["Grant Azure <azure.grant@gmail.com>"]
 categories = []
-version = "0.5.9"
+version = "0.5.10"
 repository = "https://github.com/gazure/arenabuddy"
 edition = "2024"
 rust-version = "1.88"

--- a/arenabuddy_cli/Cargo.toml
+++ b/arenabuddy_cli/Cargo.toml
@@ -11,8 +11,8 @@ version.workspace = true
 
 [dependencies]
 anyhow = { workspace = true }
-arenabuddy_core = { path = "../arenabuddy_core", version = "0.5.9" }
-arenabuddy_data = { path = "../arenabuddy_data", version = "0.5.9" }
+arenabuddy_core = { path = "../arenabuddy_core", version = "0.5.10" }
+arenabuddy_data = { path = "../arenabuddy_data", version = "0.5.10" }
 aws-config = { workspace = true, features = ["behavior-version-latest"] }
 aws-sdk-s3 = { workspace = true }
 clap = { workspace = true }

--- a/arenabuddy_core/CHANGELOG.md
+++ b/arenabuddy_core/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.10](https://github.com/gazure/arenabuddy/compare/arenabuddy_core-v0.5.9...arenabuddy_core-v0.5.10) - 2025-07-04
+
+### Added
+
+- add mana symbols to deck list view ([#89](https://github.com/gazure/arenabuddy/pull/89))
+
 ## [0.5.9](https://github.com/gazure/arenabuddy/compare/arenabuddy_core-v0.5.8...arenabuddy_core-v0.5.9) - 2025-07-03
 
 ### Added

--- a/arenabuddy_data/Cargo.toml
+++ b/arenabuddy_data/Cargo.toml
@@ -11,7 +11,7 @@ keywords.workspace = true
 license.workspace = true
 
 [dependencies]
-arenabuddy_core = { path = "../arenabuddy_core/", version = "0.5.9" }
+arenabuddy_core = { path = "../arenabuddy_core/", version = "0.5.10" }
 chrono = { workspace = true, features = ["serde"] }
 include_dir = { workspace = true }
 indoc = { workspace = true }

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -22,8 +22,8 @@ crate-type = ["staticlib", "cdylib", "rlib"]
 tauri-build = { version = "2", features = [] }
 
 [dependencies]
-arenabuddy_core = { path = "../arenabuddy_core", version = "0.5.9" }
-arenabuddy_data = { path = "../arenabuddy_data", version = "0.5.9" }
+arenabuddy_core = { path = "../arenabuddy_core", version = "0.5.10" }
+arenabuddy_data = { path = "../arenabuddy_data", version = "0.5.10" }
 tauri = { version = "2", features = [] }
 tauri-plugin-opener = "2"
 tauri-plugin-dialog = "2"


### PR DESCRIPTION



## 🤖 New release

* `arenabuddy_core`: 0.5.9 -> 0.5.10 (✓ API compatible changes)
* `arenabuddy_data`: 0.5.9 -> 0.5.10
* `arenabuddy`: 0.5.9 -> 0.5.10
* `arenabuddy_cli`: 0.5.9 -> 0.5.10

<details><summary><i><b>Changelog</b></i></summary><p>

## `arenabuddy_core`

<blockquote>

## [0.5.10](https://github.com/gazure/arenabuddy/compare/arenabuddy_core-v0.5.9...arenabuddy_core-v0.5.10) - 2025-07-04

### Added

- add mana symbols to deck list view ([#89](https://github.com/gazure/arenabuddy/pull/89))
</blockquote>

## `arenabuddy_data`

<blockquote>

## [0.5.9](https://github.com/gazure/arenabuddy/compare/arenabuddy_data-v0.5.8...arenabuddy_data-v0.5.9) - 2025-07-03

### Added

- move dir storage to data crate ([#87](https://github.com/gazure/arenabuddy/pull/87))
- move data out of core, reducing need for conditional compilation ([#85](https://github.com/gazure/arenabuddy/pull/85))

### Other

- release v0.5.8 ([#86](https://github.com/gazure/arenabuddy/pull/86))
</blockquote>

## `arenabuddy`

<blockquote>

## [0.5.8](https://github.com/gazure/arenabuddy/compare/arenabuddy-v0.5.7...arenabuddy-v0.5.8) - 2025-07-03

### Added

- move data out of core, reducing need for conditional compilation ([#85](https://github.com/gazure/arenabuddy/pull/85))
</blockquote>

## `arenabuddy_cli`

<blockquote>

## [0.5.8](https://github.com/gazure/arenabuddy/compare/arenabuddy_cli-v0.5.7...arenabuddy_cli-v0.5.8) - 2025-07-03

### Added

- move data out of core, reducing need for conditional compilation ([#85](https://github.com/gazure/arenabuddy/pull/85))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).