### PR TITLE
chore: migrate from monorepo to standalone repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,4 +49,7 @@ To get started with the ArenaBuddy development environment, follow these steps:
    - `/core` - common modules
    - `/cli` - Consolidated command line tool for log parsing and card scraping
    - `/data` - data layer
-   - `/arenabuddy` - Dioxus app
+   - `/arenabuddy` - Dioxus desktop app
+   - `/server` - gRPC backend service
+   - `/web` - Web splash page
+   - `/metagame` - Metagame scraping and deck classification

--- a/arenabuddy/src/app/pages.rs
+++ b/arenabuddy/src/app/pages.rs
@@ -10,7 +10,7 @@ use crate::{
 };
 
 fn open_github() {
-    if let Err(e) = open::that("https://github.com/gazure/monorepo") {
+    if let Err(e) = open::that("https://github.com/gazure/arenabuddy") {
         tracing::error!("Failed to open URL: {}", e);
     }
 }

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -3,8 +3,8 @@ RUN rustup target add wasm32-unknown-unknown
 RUN cargo install dioxus-cli@0.7.3 --locked
 WORKDIR /app
 COPY . .
-RUN cd arenabuddy/web && dx build --release --platform web
+RUN cd web && dx build --release --platform web
 
 FROM caddy:2-alpine AS runtime
 COPY --from=builder /app/target/dx/arenabuddy_web/release/web/public /srv
-COPY arenabuddy/web/Caddyfile /etc/caddy/Caddyfile
+COPY web/Caddyfile /etc/caddy/Caddyfile

--- a/web/src/main.rs
+++ b/web/src/main.rs
@@ -18,7 +18,7 @@ fn app() -> Element {
                 "A companion app for Magic: The Gathering Arena"
             }
             a {
-                href: "https://github.com/gazure/monorepo/releases",
+                href: "https://github.com/gazure/arenabuddy/releases",
                 target: "_blank",
                 rel: "noopener noreferrer",
                 style: "padding: 0.75rem 1.5rem; background: #4a90d9; color: #ffffff; text-decoration: none; border-radius: 0.5rem; font-size: 1.1rem; transition: background 0.2s;",


### PR DESCRIPTION
This pull request updates GitHub repository references from the old monorepo structure to the new dedicated ArenaBuddy repository. The changes include:

- Updated GitHub URL in the desktop app from `gazure/monorepo` to `gazure/arenabuddy`
- Fixed web app download link to point to `gazure/arenabuddy/releases`
- Corrected Docker build paths to reflect the new repository structure where web components are at the root level
- Enhanced README documentation to clarify the purpose of each directory, specifying the Dioxus desktop app, gRPC backend service, web splash page, and metagame scraping components