### PR TITLE
refactor: change launch function to accept string reference

### DIFF
--- a/arenabuddy/src/backend/launch.rs
+++ b/arenabuddy/src/backend/launch.rs
@@ -9,8 +9,7 @@ use dioxus::{
 use tracing::{error, info};
 use tracing_appender::rolling::{RollingFileAppender, Rotation};
 use tracing_subscriber::{
-    EnvFilter,
-    fmt,
+    EnvFilter, fmt,
     layer::{Layer, SubscriberExt},
     registry,
     util::SubscriberInitExt,
@@ -27,7 +26,7 @@ use crate::{
 pub type BackgroundRuntime = Arc<tokio::runtime::Runtime>;
 
 #[tracing::instrument(name = "app")]
-pub fn launch(app: String) -> Result<()> {
+pub fn launch(app: &str) -> Result<()> {
     let background: BackgroundRuntime = Arc::new(tokio::runtime::Runtime::new()?);
     let service = background.block_on(create_app_service())?;
 
@@ -113,8 +112,7 @@ fn setup_logging(app_data_dir: &Path) -> Result<()> {
         .with_file(true)
         .with_level(true);
 
-    let console_filter =
-        EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info"));
+    let console_filter = EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info"));
 
     let registry = registry
         .with(file_layer)

--- a/arenabuddy/src/main.rs
+++ b/arenabuddy/src/main.rs
@@ -2,6 +2,6 @@
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let app_name = std::env::var("APP_NAME").unwrap_or_else(|_| "arenabuddy".to_string());
-    arenabuddy::launch(app_name)?;
+    arenabuddy::launch(&app_name)?;
     Ok(())
 }


### PR DESCRIPTION
This pull request changes the `launch` function parameter from `String` to `&str` to accept a string reference instead of an owned string. The function signature is updated in `launch.rs` and the corresponding function call in `main.rs` is modified to pass a reference to the app name string. Additionally, some minor formatting improvements are made to import statements and variable declarations.