### PR TITLE
feat: add Loki and Promtail for centralized logging

### DIFF
--- a/server/docker-compose.yml
+++ b/server/docker-compose.yml
@@ -24,6 +24,24 @@ services:
       - ./tempo.yaml:/etc/tempo.yaml:ro
       - tempo_data:/var/tempo
 
+  loki:
+    image: grafana/loki:3.4.2
+    restart: unless-stopped
+    command: ["-config.file=/etc/loki/local-config.yaml"]
+    volumes:
+      - loki_data:/loki
+
+  promtail:
+    image: grafana/promtail:3.4.2
+    restart: unless-stopped
+    depends_on:
+      - loki
+    command: ["-config.file=/etc/promtail/promtail.yaml"]
+    volumes:
+      - ./promtail.yaml:/etc/promtail/promtail.yaml:ro
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+      - /var/lib/docker/containers:/var/lib/docker/containers:ro
+
   server:
     image: ${SERVER_IMAGE:-arenabuddy-server:latest}
     restart: unless-stopped
@@ -65,6 +83,7 @@ services:
     restart: unless-stopped
     depends_on:
       - tempo
+      - loki
     expose:
       - "3000"
     volumes:
@@ -79,4 +98,5 @@ volumes:
   caddy_data:
   caddy_config:
   tempo_data:
+  loki_data:
   grafana_data:

--- a/server/grafana/provisioning/datasources/datasources.yml
+++ b/server/grafana/provisioning/datasources/datasources.yml
@@ -11,6 +11,18 @@ datasources:
       nodeGraph:
         enabled: true
 
+  - name: Loki
+    type: loki
+    access: proxy
+    url: http://loki:3100
+    editable: true
+    jsonData:
+      derivedFields:
+        - datasourceUid: tempo
+          matcherRegex: '"trace_id":"(\w+)"'
+          name: TraceID
+          url: "$${__value.raw}"
+
   - name: PostgreSQL
     type: postgres
     access: proxy

--- a/server/promtail.yaml
+++ b/server/promtail.yaml
@@ -1,0 +1,33 @@
+server:
+  http_listen_port: 9080
+  grpc_listen_port: 0
+
+positions:
+  filename: /tmp/positions.yaml
+
+clients:
+  - url: http://loki:3100/loki/api/v1/push
+
+scrape_configs:
+  - job_name: docker
+    docker_sd_configs:
+      - host: unix:///var/run/docker.sock
+        refresh_interval: 5s
+    relabel_configs:
+      # Keep only containers from this compose project
+      - source_labels: ["__meta_docker_container_name"]
+        regex: "/(.*)"
+        target_label: "container"
+      - source_labels: ["__meta_docker_container_label_com_docker_compose_service"]
+        target_label: "service"
+      - source_labels: ["__meta_docker_container_label_com_docker_compose_project"]
+        target_label: "project"
+    pipeline_stages:
+      - json:
+          expressions:
+            level: level
+            target: target
+            message: fields.message
+      - labels:
+          level:
+          target:

--- a/server/src/otel.rs
+++ b/server/src/otel.rs
@@ -42,15 +42,7 @@ pub fn init_compact_with_otel(service_name: &str) -> OtelGuard {
 
     Registry::default()
         .with(env_filter)
-        .with(
-            fmt::layer()
-                .compact()
-                .with_target(true)
-                .with_level(true)
-                .with_file(false)
-                .with_line_number(false)
-                .with_thread_names(false),
-        )
+        .with(fmt::layer().json())
         .with(otel_layer)
         .init();
 


### PR DESCRIPTION
This pull request adds Loki log aggregation to the observability stack. It introduces a Loki service and Promtail log collector to the Docker Compose configuration, configures Grafana to use Loki as a datasource with trace correlation capabilities, and switches the application logging format from compact to JSON to improve log parsing and analysis.