### PR TITLE
feat: add database name to Grafana PostgreSQL datasource

### DIFF
--- a/server/grafana/provisioning/datasources/datasources.yml
+++ b/server/grafana/provisioning/datasources/datasources.yml
@@ -32,6 +32,7 @@ datasources:
     secureJsonData:
       password: ${POSTGRES_PASSWORD}
     jsonData:
+      database: arenabuddy
       sslmode: disable
       postgresVersion: 1700
     editable: true


### PR DESCRIPTION
This pull request adds the database name "arenabuddy" to the Grafana PostgreSQL datasource configuration. The database field is now explicitly specified in the jsonData section of the datasource provisioning file.