### PR TITLE
feat: add DistributionReq/Resp message types to client and GRE events

### DIFF
--- a/core/src/events/client.rs
+++ b/core/src/events/client.rs
@@ -107,8 +107,8 @@ pub enum ClientMessage {
     UndoReq(UndoReqWrapper),
     #[serde(rename = "ClientMessageType_SelectCountersResp")]
     SelectCountersResp(SelectCountersRespWrapper),
-    #[serde(rename =  "ClientMessageType_DistributionResp")]
-    DistributionResp(DistributionRespWrapper)
+    #[serde(rename = "ClientMessageType_DistributionResp")]
+    DistributionResp(DistributionRespWrapper),
 }
 
 wrapper!(AssignDamageRespWrapper, AssignDamageResp, assign_damage_resp);
@@ -157,7 +157,6 @@ wrapper!(
     order_combat_damage_resp
 );
 wrapper!(DistributionRespWrapper, DistributionResp, distribution_resp);
-
 
 #[derive(Debug, Default, Clone, PartialEq, Deserialize, Serialize)]
 pub struct UndoReqWrapper {
@@ -508,7 +507,7 @@ pub struct PerformActionResp {
 #[derive(Debug, Default, Clone, PartialEq, Deserialize, Serialize)]
 pub struct DistributionResp {
     #[serde(flatten)]
-    pub extra: HashMap<String, Value>
+    pub extra: HashMap<String, Value>,
 }
 
 #[derive(Debug, Default, Clone, PartialEq, Deserialize, Serialize)]

--- a/core/src/events/client.rs
+++ b/core/src/events/client.rs
@@ -107,6 +107,8 @@ pub enum ClientMessage {
     UndoReq(UndoReqWrapper),
     #[serde(rename = "ClientMessageType_SelectCountersResp")]
     SelectCountersResp(SelectCountersRespWrapper),
+    #[serde(rename =  "ClientMessageType_DistributionResp")]
+    DistributionResp(DistributionRespWrapper)
 }
 
 wrapper!(AssignDamageRespWrapper, AssignDamageResp, assign_damage_resp);
@@ -154,6 +156,8 @@ wrapper!(
     OrderCombatDamageResp,
     order_combat_damage_resp
 );
+wrapper!(DistributionRespWrapper, DistributionResp, distribution_resp);
+
 
 #[derive(Debug, Default, Clone, PartialEq, Deserialize, Serialize)]
 pub struct UndoReqWrapper {
@@ -499,6 +503,12 @@ pub enum MulliganOption {
 #[derive(Debug, Default, Clone, PartialEq, Deserialize, Serialize)]
 pub struct PerformActionResp {
     pub actions: Vec<Action>,
+}
+
+#[derive(Debug, Default, Clone, PartialEq, Deserialize, Serialize)]
+pub struct DistributionResp {
+    #[serde(flatten)]
+    pub extra: HashMap<String, Value>
 }
 
 #[derive(Debug, Default, Clone, PartialEq, Deserialize, Serialize)]

--- a/core/src/events/gre.rs
+++ b/core/src/events/gre.rs
@@ -13,8 +13,7 @@ use crate::{
 
 // GRE refers to the server-side MTGA engine
 //
-// no clue what it actually stands for, but these are a bunch of events that come from
-// the server to the game client
+// Probably stands for GameRulesEngine
 
 macro_rules! wrapper {
     ($wrapperName:ident, $name:ident, $snake:ident) => {
@@ -130,6 +129,8 @@ pub enum GREToClientMessage {
     IllegalRequest(IllegalRequestWrapper),
     #[serde(rename = "GREMessageType_SelectCountersReq")]
     SelectCountersReq(SelectCountersReqWrapper),
+    #[serde(rename = "GREMessageType_DistributionReq")]
+    DistributionReq(DistributionReqWrapper),
     #[default]
     Default,
 }
@@ -144,6 +145,7 @@ pub struct GreMeta {
     pub game_state_id: Option<i32>,
 }
 
+wrapper!(DistributionReqWrapper);
 wrapper!(IllegalRequestWrapper);
 wrapper!(SelectCountersReqWrapper);
 wrapper!(AssignDamageReqWrapper);


### PR DESCRIPTION
This pull request adds support for distribution request and response messages in the MTGA event system. 

**Changes:**
- Added `DistributionReq` variant to `GREToClientMessage` enum with serde rename attribute
- Added `DistributionResp` variant to `ClientMessage` enum with serde rename attribute  
- Created `DistributionRespWrapper` and `DistributionReqWrapper` using the wrapper macro
- Implemented `DistributionResp` struct with a flattened extra fields HashMap
- Updated comment in GRE module to clarify that GRE likely stands for "GameRulesEngine"

These additions enable handling of distribution-related game events flowing between the server's game rules engine and the client.