### PR TITLE
Add AGENTS.md with Cursor Cloud development instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,31 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+### Overview
+
+ArenaBuddy is an MTGA companion app. The workspace has 7 crates: `core`, `data`, `cli`, `arenabuddy` (Dioxus desktop), `server` (gRPC), `web` (Dioxus WASM), and `metagame`. See `README.md` for project structure.
+
+### Build and check commands
+
+All standard commands are in `CLAUDE.md`. Key point: always set `SQLX_OFFLINE=true` when running `cargo check`, `cargo clippy`, or `cargo test` — the `.sqlx/` directory has cached query metadata so no live PostgreSQL is needed for compilation.
+
+```bash
+SQLX_OFFLINE=true cargo check --profile ci --workspace --all-targets --all-features
+SQLX_OFFLINE=true cargo clippy --profile ci --all --all-targets --all-features --examples --tests
+cargo +nightly fmt --all -- --check
+SQLX_OFFLINE=true cargo test -p <crate>
+```
+
+### System dependencies (pre-installed in snapshot)
+
+- `protobuf-compiler` — required by `core/build.rs` to compile `.proto` files
+- GTK/WebKit dev libraries — required for the Dioxus desktop app (`arenabuddy` crate): `libwebkit2gtk-4.1-dev`, `libgtk-3-dev`, `libayatana-appindicator3-dev`, `libssl-dev`, `libxdo-dev`, `libsoup-3.0-dev`, `librsvg2-dev`
+
+### Gotchas
+
+- The `data` crate uses `sqlx.toml` with `database-url-var = "ARENABUDDY_DATABASE_URL"` (not the standard `DATABASE_URL`). For offline mode set `SQLX_OFFLINE=true`.
+- Rust edition 2024 requires `rust-version = "1.94"`. The snapshot has stable 1.94+ and nightly installed.
+- The desktop app (`arenabuddy` crate) and web app (`web` crate) use Dioxus 0.7.3. Building them with `dx serve` requires the Dioxus CLI, but `cargo check`/`clippy`/`test` work without it.
+- The server requires PostgreSQL, Discord OAuth credentials, and a JWT secret to run. For compile/test, `SQLX_OFFLINE=true` is sufficient.
+- Integration tests for `arenabuddy_data` may attempt to start an embedded PostgreSQL; this is handled by the `postgresql_embedded` crate with the `bundled` feature.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds `AGENTS.md` with Cursor Cloud specific instructions for future cloud agents, including:

- Build/check commands with `SQLX_OFFLINE=true` requirement
- System dependency notes (protoc, GTK/WebKit dev libs)
- Key gotchas: custom `ARENABUDDY_DATABASE_URL` var in sqlx.toml, Rust 1.94+ requirement, Dioxus CLI vs cargo check distinction, server credential requirements

**Environment verified:**
- Rust stable 1.94.1 + nightly installed
- `protoc` 3.21.12 installed
- All GTK/WebKit dev libraries installed for Dioxus desktop builds

**All checks pass:**

[build_and_test.log](https://cursor.com/agents/bc-c88efbd8-7121-47bc-b39b-2c723bf78f8f/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fbuild_and_test.log)

- `cargo check --profile ci --workspace --all-targets --all-features`
- `cargo clippy --profile ci --all --all-targets --all-features --examples --tests`
- `cargo +nightly fmt --all -- --check`
- `cargo test -p arenabuddy_core` (28 passed)
- `cargo test -p arenabuddy_data` (3 passed)
- `cargo test -p arenabuddy_metagame` (8 passed)
- `cargo test -p arenabuddy_server` (0 tests, compiles ok)

**CLI demo:**

[cli_demo.log](https://cursor.com/agents/bc-c88efbd8-7121-47bc-b39b-2c723bf78f8f/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fcli_demo.log)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c88efbd8-7121-47bc-b39b-2c723bf78f8f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c88efbd8-7121-47bc-b39b-2c723bf78f8f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

