### PR TITLE
Update BREAK.svg stroke color to white and increase width

### DIFF
--- a/arenabuddy/assets/mana/BREAK.svg
+++ b/arenabuddy/assets/mana/BREAK.svg
@@ -1,4 +1,4 @@
 <svg width="100" height="100" xmlns="http://www.w3.org/2000/svg">
-  <line x1="30" y1="70" x2="40" y2="30" stroke="black" stroke-width="2"/>
-  <line x1="60" y1="70" x2="70" y2="30" stroke="black" stroke-width="2"/>
+  <line x1="30" y1="70" x2="40" y2="30" stroke="white" stroke-width="4"/>
+  <line x1="60" y1="70" x2="70" y2="30" stroke="white" stroke-width="4"/>
 </svg>


### PR DESCRIPTION
This pull request updates the BREAK mana symbol by changing the stroke color from black to white and increasing the stroke width from 2 to 4 pixels for both diagonal lines in the SVG.