### PR TITLE
refactor: extract shared wrapper macros to dedicated module

### DIFF
--- a/core/src/events/client.rs
+++ b/core/src/events/client.rs
@@ -11,18 +11,6 @@ use crate::events::{
 // Client messages to the game server
 //
 
-macro_rules! wrapper {
-    ($wrapperName:ident, $name:ident, $snake:ident) => {
-        #[derive(Debug, Default, Clone, PartialEq, Deserialize, Serialize)]
-        #[serde(rename_all = "camelCase")]
-        pub struct $wrapperName {
-            #[serde(flatten)]
-            pub meta: ClientMeta,
-            pub $snake: $name,
-        }
-    };
-}
-
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct RequestTypeClientToMatchServiceMessage {
     #[serde(rename = "clientToMatchServiceMessageType")]
@@ -111,52 +99,52 @@ pub enum ClientMessage {
     DistributionResp(DistributionRespWrapper),
 }
 
-wrapper!(AssignDamageRespWrapper, AssignDamageResp, assign_damage_resp);
-wrapper!(SetSettingsReqWrapper, SetSettingsReq, set_settings_req);
-wrapper!(SubmitDeckRespWrapper, SubmitDeckResp, submit_deck_resp);
-wrapper!(MulliganRespWrapper, MulliganResp, mulligan_resp);
-wrapper!(PerformActionRespWrapper, PerformActionResp, perform_action_resp);
-wrapper!(UIMessageWrapper, UIMessage, ui_message);
-wrapper!(SelectNRespWrapper, SelectNResp, select_n_resp);
-wrapper!(SelectTargetsRespWrapper, SelectTargetsResp, select_targets_resp);
-wrapper!(
+client_payload_wrapper!(AssignDamageRespWrapper, AssignDamageResp, assign_damage_resp);
+client_payload_wrapper!(SetSettingsReqWrapper, SetSettingsReq, set_settings_req);
+client_payload_wrapper!(SubmitDeckRespWrapper, SubmitDeckResp, submit_deck_resp);
+client_payload_wrapper!(MulliganRespWrapper, MulliganResp, mulligan_resp);
+client_payload_wrapper!(PerformActionRespWrapper, PerformActionResp, perform_action_resp);
+client_payload_wrapper!(UIMessageWrapper, UIMessage, ui_message);
+client_payload_wrapper!(SelectNRespWrapper, SelectNResp, select_n_resp);
+client_payload_wrapper!(SelectTargetsRespWrapper, SelectTargetsResp, select_targets_resp);
+client_payload_wrapper!(
     DeclareAttackersRespWrapper,
     DeclareAttackersResp,
     declare_attackers_resp
 );
-wrapper!(ConcedeReqWrapper, ConcedeReq, concede_req);
-wrapper!(EffectCostRespWrapper, EffectCostResp, effect_cost_resp);
-wrapper!(
+client_payload_wrapper!(ConcedeReqWrapper, ConcedeReq, concede_req);
+client_payload_wrapper!(EffectCostRespWrapper, EffectCostResp, effect_cost_resp);
+client_payload_wrapper!(
     ChooseStartingPlayerRespWrapper,
     ChooseStartingPlayerResp,
     choose_starting_player_resp
 );
-wrapper!(CancelActionReqWrapper, CancelActionReq, cancel_action_req);
-wrapper!(
+client_payload_wrapper!(CancelActionReqWrapper, CancelActionReq, cancel_action_req);
+client_payload_wrapper!(
     CastingTimeOptionRespWrapper,
     CastingTimeOptionResp,
     casting_time_option_resp
 );
-wrapper!(
+client_payload_wrapper!(
     CastingTimeOptionsRespWrapperWrapper,
     CastingTimeOptionRespWrapper,
     casting_time_options_resp
 );
-wrapper!(
+client_payload_wrapper!(
     PerformAutoTapActionsRespWrapper,
     PerformAutoTapActionsResp,
     perform_auto_tap_actions_resp
 );
-wrapper!(OrderRespWrapper, OrderResp, order_resp);
-wrapper!(SearchRespWrapper, SearchResp, search_resp);
-wrapper!(OptionalActionRespWrapper, OptionalActionResp, optional_resp);
-wrapper!(GroupRespWrapper, GroupResp, group_resp);
-wrapper!(
+client_payload_wrapper!(OrderRespWrapper, OrderResp, order_resp);
+client_payload_wrapper!(SearchRespWrapper, SearchResp, search_resp);
+client_payload_wrapper!(OptionalActionRespWrapper, OptionalActionResp, optional_resp);
+client_payload_wrapper!(GroupRespWrapper, GroupResp, group_resp);
+client_payload_wrapper!(
     OrderCombatDamageRespWrapper,
     OrderCombatDamageResp,
     order_combat_damage_resp
 );
-wrapper!(DistributionRespWrapper, DistributionResp, distribution_resp);
+client_payload_wrapper!(DistributionRespWrapper, DistributionResp, distribution_resp);
 
 #[derive(Debug, Default, Clone, PartialEq, Deserialize, Serialize)]
 pub struct UndoReqWrapper {

--- a/core/src/events/gre.rs
+++ b/core/src/events/gre.rs
@@ -1,7 +1,4 @@
-use std::collections::HashMap;
-
 use serde::{Deserialize, Serialize};
-use serde_json::Value;
 
 use crate::{
     events::primitives::{
@@ -14,28 +11,6 @@ use crate::{
 // GRE refers to the server-side MTGA engine
 //
 // Probably stands for GameRulesEngine
-
-macro_rules! wrapper {
-    ($wrapperName:ident, $name:ident, $snake:ident) => {
-        #[derive(Debug, Default, Clone, PartialEq, Deserialize, Serialize)]
-        #[serde(rename_all = "camelCase")]
-        pub struct $wrapperName {
-            #[serde(flatten)]
-            pub meta: GreMeta,
-            pub $snake: $name,
-        }
-    };
-    ($wrapperName:ident) => {
-        #[derive(Debug, Default, Clone, PartialEq, Deserialize, Serialize)]
-        #[serde(rename_all = "camelCase")]
-        pub struct $wrapperName {
-            #[serde(flatten)]
-            pub meta: GreMeta,
-            #[serde(flatten)]
-            pub extra: HashMap<String, Value>,
-        }
-    };
-}
 
 #[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -145,42 +120,42 @@ pub struct GreMeta {
     pub game_state_id: Option<i32>,
 }
 
-wrapper!(DistributionReqWrapper);
-wrapper!(IllegalRequestWrapper);
-wrapper!(SelectCountersReqWrapper);
-wrapper!(AssignDamageReqWrapper);
-wrapper!(AssignDamageConfirmationWrapper);
-wrapper!(OrderDamageConfirmationWrapper);
-wrapper!(OrderCombatDamageReqWrapper);
-wrapper!(EdictalMessageWrapper);
-wrapper!(TimeoutMessageWrapper);
-wrapper!(GroupRespWrapper);
-wrapper!(GroupReqWrapper);
-wrapper!(OptionalActionMessageWrapper);
-wrapper!(SearchReqWrapper);
-wrapper!(SubmitDeckWrapper);
-wrapper!(OrderReqWrapper);
-wrapper!(SubmitBlockersRespWrapper);
-wrapper!(DeclareBlockersReqWrapper);
-wrapper!(UIMessageWrapper);
-wrapper!(SubmitDeckConfirmationWrapper);
-wrapper!(SubmitDeckReqWrapper);
-wrapper!(SubmitAttackersRespWrapper);
-wrapper!(DeclareAttackersReqWrapper);
-wrapper!(SelectNRespWrapper);
-wrapper!(PayCostsReqWrapper);
-wrapper!(IntermissionReqWrapper, IntermissionReq, intermission_req);
-wrapper!(CastingTimeOptionsReqWrapper);
-wrapper!(ChooseStartingPlayerReqWrapper);
-wrapper!(SubmitTargetsRespWrapper, SubmitTargetsResp, submit_targets_resp);
-wrapper!(ConnectRespWrapper, ConnectResp, connect_resp);
-wrapper!(DieRollResultsRespWrapper, DieRollResultsResp, die_roll_results_resp);
-wrapper!(ActionsAvailableReqWrapper, ActionsAvailableReq, actions_available_req);
-wrapper!(PromptReqWrapper, Prompt, prompt);
-wrapper!(SetSettingsRespWrapper, SetSettingsResp, set_settings_resp);
-wrapper!(QueuedStateMessageWrapper);
-wrapper!(TimerStateMessageWrapper);
-wrapper!(GameStateMessageWrapper, GameStateMessage, game_state_message);
+gre_extra_wrapper!(DistributionReqWrapper);
+gre_extra_wrapper!(IllegalRequestWrapper);
+gre_extra_wrapper!(SelectCountersReqWrapper);
+gre_extra_wrapper!(AssignDamageReqWrapper);
+gre_extra_wrapper!(AssignDamageConfirmationWrapper);
+gre_extra_wrapper!(OrderDamageConfirmationWrapper);
+gre_extra_wrapper!(OrderCombatDamageReqWrapper);
+gre_extra_wrapper!(EdictalMessageWrapper);
+gre_extra_wrapper!(TimeoutMessageWrapper);
+gre_extra_wrapper!(GroupRespWrapper);
+gre_extra_wrapper!(GroupReqWrapper);
+gre_extra_wrapper!(OptionalActionMessageWrapper);
+gre_extra_wrapper!(SearchReqWrapper);
+gre_extra_wrapper!(SubmitDeckWrapper);
+gre_extra_wrapper!(OrderReqWrapper);
+gre_extra_wrapper!(SubmitBlockersRespWrapper);
+gre_extra_wrapper!(DeclareBlockersReqWrapper);
+gre_extra_wrapper!(UIMessageWrapper);
+gre_extra_wrapper!(SubmitDeckConfirmationWrapper);
+gre_extra_wrapper!(SubmitDeckReqWrapper);
+gre_extra_wrapper!(SubmitAttackersRespWrapper);
+gre_extra_wrapper!(DeclareAttackersReqWrapper);
+gre_extra_wrapper!(SelectNRespWrapper);
+gre_extra_wrapper!(PayCostsReqWrapper);
+gre_payload_wrapper!(IntermissionReqWrapper, IntermissionReq, intermission_req);
+gre_extra_wrapper!(CastingTimeOptionsReqWrapper);
+gre_extra_wrapper!(ChooseStartingPlayerReqWrapper);
+gre_payload_wrapper!(SubmitTargetsRespWrapper, SubmitTargetsResp, submit_targets_resp);
+gre_payload_wrapper!(ConnectRespWrapper, ConnectResp, connect_resp);
+gre_payload_wrapper!(DieRollResultsRespWrapper, DieRollResultsResp, die_roll_results_resp);
+gre_payload_wrapper!(ActionsAvailableReqWrapper, ActionsAvailableReq, actions_available_req);
+gre_payload_wrapper!(PromptReqWrapper, Prompt, prompt);
+gre_payload_wrapper!(SetSettingsRespWrapper, SetSettingsResp, set_settings_resp);
+gre_extra_wrapper!(QueuedStateMessageWrapper);
+gre_extra_wrapper!(TimerStateMessageWrapper);
+gre_payload_wrapper!(GameStateMessageWrapper, GameStateMessage, game_state_message);
 
 #[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]

--- a/core/src/events/macros.rs
+++ b/core/src/events/macros.rs
@@ -1,0 +1,39 @@
+//! Declarative macros for serde wrapper structs shared by [`gre`](crate::events::gre) and
+//! [`client`](crate::events::client).
+
+macro_rules! meta_payload_wrapper {
+    ($meta:path, $wrapper:ident, $inner:ty, $field:ident) => {
+        #[derive(Debug, Default, Clone, PartialEq, Deserialize, Serialize)]
+        #[serde(rename_all = "camelCase")]
+        pub struct $wrapper {
+            #[serde(flatten)]
+            pub meta: $meta,
+            pub $field: $inner,
+        }
+    };
+}
+
+macro_rules! gre_payload_wrapper {
+    ($wrapper:ident, $inner:ty, $field:ident) => {
+        meta_payload_wrapper!(crate::events::gre::GreMeta, $wrapper, $inner, $field);
+    };
+}
+
+macro_rules! client_payload_wrapper {
+    ($wrapper:ident, $inner:ty, $field:ident) => {
+        meta_payload_wrapper!(crate::events::client::ClientMeta, $wrapper, $inner, $field);
+    };
+}
+
+macro_rules! gre_extra_wrapper {
+    ($wrapper:ident) => {
+        #[derive(Debug, Default, Clone, PartialEq, Deserialize, Serialize)]
+        #[serde(rename_all = "camelCase")]
+        pub struct $wrapper {
+            #[serde(flatten)]
+            pub meta: crate::events::gre::GreMeta,
+            #[serde(flatten)]
+            pub extra: std::collections::HashMap<String, serde_json::Value>,
+        }
+    };
+}

--- a/core/src/events/mod.rs
+++ b/core/src/events/mod.rs
@@ -1,3 +1,5 @@
+#[macro_use]
+mod macros;
 pub mod business;
 pub mod client;
 pub mod draft;


### PR DESCRIPTION
This pull request refactors the macro system for event wrapper structs by extracting duplicate macro definitions into a shared module. The changes include:

- Removes duplicate `wrapper` macro definitions from both `client.rs` and `gre.rs` files
- Creates a new `macros.rs` module containing four specialized macros:
  - `meta_payload_wrapper!` - Generic macro for creating wrapper structs with metadata and payload
  - `gre_payload_wrapper!` - GRE-specific wrapper for structs with typed payloads
  - `client_payload_wrapper!` - Client-specific wrapper for structs with typed payloads  
  - `gre_extra_wrapper!` - GRE-specific wrapper for structs with extra HashMap fields
- Updates all wrapper struct declarations to use the appropriate new macro names
- Removes unused imports (`std::collections::HashMap` and `serde_json::Value`) from `gre.rs`
- Adds the macros module to `mod.rs` with `#[macro_use]` attribute

The refactoring maintains the same functionality while eliminating code duplication and providing more descriptive macro names that clearly indicate their intended use case.