### PR TITLE
feat: add manual match sync button to match details view

### DIFF
--- a/arenabuddy/assets/tailwind.css
+++ b/arenabuddy/assets/tailwind.css
@@ -702,6 +702,9 @@
   .bg-emerald-600 {
     background-color: var(--color-emerald-600);
   }
+  .bg-emerald-700 {
+    background-color: var(--color-emerald-700);
+  }
   .bg-emerald-900\/30 {
     background-color: color-mix(in srgb, oklch(37.8% 0.077 168.94) 30%, transparent);
     @supports (color: color-mix(in lab, red, red)) {
@@ -1001,6 +1004,9 @@
   .opacity-80 {
     opacity: 80%;
   }
+  .opacity-90 {
+    opacity: 90%;
+  }
   .shadow {
     --tw-shadow: 0 1px 3px 0 var(--tw-shadow-color, rgb(0 0 0 / 0.1)), 0 1px 2px -1px var(--tw-shadow-color, rgb(0 0 0 / 0.1));
     box-shadow: var(--tw-inset-shadow), var(--tw-inset-ring-shadow), var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow);
@@ -1093,6 +1099,13 @@
         @supports (color: color-mix(in lab, red, red)) {
           background-color: color-mix(in oklab, var(--color-blue-900) 30%, transparent);
         }
+      }
+    }
+  }
+  .hover\:bg-emerald-600 {
+    &:hover {
+      @media (hover: hover) {
+        background-color: var(--color-emerald-600);
       }
     }
   }
@@ -1208,6 +1221,11 @@
   .disabled\:opacity-50 {
     &:disabled {
       opacity: 50%;
+    }
+  }
+  .disabled\:opacity-60 {
+    &:disabled {
+      opacity: 60%;
     }
   }
   .sm\:grid-cols-5 {

--- a/arenabuddy/src/app/match_details.rs
+++ b/arenabuddy/src/app/match_details.rs
@@ -5,12 +5,15 @@ use crate::{
         Route,
         components::{DeckList, EventLogDisplay, MatchInfo, MulliganDisplay},
     },
-    backend::Service,
+    backend::{Service, SharedAuthState, sync},
 };
 
 #[component]
 pub(crate) fn MatchDetails(id: String) -> Element {
     let service = use_context::<Service>();
+    let auth_state = use_context::<SharedAuthState>();
+    let mut sync_loading = use_signal(|| false);
+    let mut sync_status = use_signal(|| None::<String>);
 
     let mut match_details = use_resource({
         let service = service.clone();
@@ -24,6 +27,36 @@ pub(crate) fn MatchDetails(id: String) -> Element {
 
     let refresh = move |_| {
         match_details.restart();
+    };
+
+    let on_sync = {
+        let auth_state = auth_state.clone();
+        let service = service.clone();
+        let id = id.clone();
+        move |_| {
+            let auth_state = auth_state.clone();
+            let service = service.clone();
+            let id = id.clone();
+            spawn(async move {
+                sync_loading.set(true);
+                sync_status.set(None);
+
+                match sync::push_match(&service.db, &auth_state, &id).await {
+                    Ok(true) => {
+                        sync_status.set(Some("Pushed local match to server".to_string()));
+                        match_details.restart();
+                    }
+                    Ok(false) => {
+                        sync_status.set(Some("Local match not found".to_string()));
+                    }
+                    Err(e) => {
+                        sync_status.set(Some(format!("Push failed: {e}")));
+                    }
+                }
+
+                sync_loading.set(false);
+            });
+        }
     };
 
     let resource_value = match_details.value();
@@ -56,9 +89,30 @@ pub(crate) fn MatchDetails(id: String) -> Element {
                     h1 { class: "text-3xl font-bold", "Match Details" }
                     div { class: "flex gap-2",
                         button {
+                            onclick: on_sync,
+                            class: "bg-emerald-700 hover:bg-emerald-600 text-white font-semibold py-2 px-4 rounded-full transition-all duration-200 shadow-md hover:shadow-lg flex items-center disabled:opacity-60 disabled:cursor-not-allowed",
+                            disabled: sync_loading(),
+                            span { class: "mr-2",
+                                if sync_loading() { "Syncing..." } else { "Sync" }
+                            }
+                            svg {
+                                xmlns: "http://www.w3.org/2000/svg",
+                                class: "h-5 w-5",
+                                fill: "none",
+                                view_box: "0 0 24 24",
+                                stroke: "currentColor",
+                                path {
+                                    stroke_linecap: "round",
+                                    stroke_linejoin: "round",
+                                    stroke_width: "2",
+                                    d: "M12 4v16m8-8H4"
+                                }
+                            }
+                        }
+                        button {
                             onclick: refresh,
                             class: "bg-black bg-opacity-20 hover:bg-opacity-30 text-white font-semibold py-2 px-4 rounded-full transition-all duration-200 shadow-md hover:shadow-lg flex items-center",
-                            disabled: data.is_none(),
+                            disabled: data.is_none() || sync_loading(),
                             span { class: "mr-2",
                                 if data.is_none() { "Loading..." } else { "Refresh" }
                             }
@@ -82,6 +136,9 @@ pub(crate) fn MatchDetails(id: String) -> Element {
                 p { class: "text-lg opacity-80 mt-2",
                     span { class: "font-semibold", "Match ID:" }
                     " {id}"
+                }
+                if let Some(message) = sync_status() {
+                    p { class: "text-sm opacity-90 mt-2", "{message}" }
                 }
             }
 

--- a/arenabuddy/src/backend/sync.rs
+++ b/arenabuddy/src/backend/sync.rs
@@ -1,8 +1,10 @@
 use std::collections::HashSet;
 
 use arenabuddy_core::{
-    models::MatchData,
-    services::match_service::{GetMatchDataRequest, ListMatchesRequest, match_service_client::MatchServiceClient},
+    models::{ArenaId, MatchData, OpponentDeck},
+    services::match_service::{
+        GetMatchDataRequest, ListMatchesRequest, UpsertMatchDataRequest, match_service_client::MatchServiceClient,
+    },
 };
 use arenabuddy_data::{ArenabuddyRepository, MatchDB};
 use tracing::{error, info};
@@ -136,4 +138,51 @@ pub async fn sync_matches(
 
     info!("Synced {synced}/{} matches from server", missing.len());
     Ok(synced)
+}
+
+/// Push a specific local match to the server via gRPC upsert.
+///
+/// Returns `Ok(true)` when the local match exists and was uploaded.
+/// Returns `Ok(false)` when the local match is missing.
+pub async fn push_match(
+    db: &MatchDB,
+    auth_state: &SharedAuthState,
+    match_id: &str,
+) -> Result<bool, Box<dyn std::error::Error + Send + Sync>> {
+    let grpc_url = super::paths::grpc_url();
+    let token = current_token(auth_state, &grpc_url).await.ok_or("not authenticated")?;
+
+    let Ok((mtga_match, _result)) = db.get_match(match_id, None).await else {
+        return Ok(false);
+    };
+    let decks = db.list_decklists(match_id).await?;
+    let mulligans = db.list_mulligans(match_id).await?;
+    let results = db.list_match_results(match_id).await?;
+    let event_logs = db.list_event_logs(match_id).await?;
+    let opponent_deck = db
+        .get_opponent_deck(match_id)
+        .await
+        .ok()
+        .map_or_else(OpponentDeck::empty, |d| {
+            OpponentDeck::new(d.mainboard().iter().map(|&id| ArenaId::from(id)).collect())
+        });
+
+    let match_data = MatchData {
+        mtga_match,
+        decks,
+        mulligans,
+        results,
+        opponent_deck,
+        event_logs,
+    };
+
+    let mut request = tonic::Request::new(UpsertMatchDataRequest {
+        match_data: Some((&match_data).into()),
+    });
+    attach_token(&mut request, &token);
+
+    let mut client = MatchServiceClient::connect(grpc_url).await?;
+    client.upsert_match_data(request).await?;
+    info!("Pushed local match {match_id} to server");
+    Ok(true)
 }


### PR DESCRIPTION
Adds a **Sync** button to the Match Details page that allows pushing an individual local match to the remote server on demand.

Previously, syncing only pulled matches from the server in bulk. The new `push_match` function in `sync.rs` assembles the full `MatchData` payload for a given match ID — including decklists, mulligans, results, event logs, and the opponent deck — and uploads it via the gRPC `UpsertMatchDataRequest` endpoint using the current auth token.

The Match Details UI gains a dedicated Sync button alongside the existing Refresh button. While a sync is in progress, both buttons are disabled and the Sync button displays "Syncing..." to indicate activity. Once the operation completes, a status message is shown below the match ID indicating whether the push succeeded, the match was not found locally, or an error occurred.