### PR TITLE
refactor: scope logout and token reuse to single token instead of all user tokens

### DIFF
--- a/data/src/db/auth_repository.rs
+++ b/data/src/db/auth_repository.rs
@@ -11,7 +11,7 @@ pub trait AuthRepository: Send + Sync + 'static {
     async fn create_refresh_token(&self, user_id: Uuid, token_hash: &[u8], expires_at: DateTime<Utc>) -> Result<()>;
     async fn find_refresh_token(&self, token_hash: &[u8]) -> Result<Option<RefreshToken>>;
     async fn revoke_refresh_token(&self, token_id: Uuid) -> Result<()>;
-    async fn revoke_all_user_tokens(&self, user_id: Uuid) -> Result<()>;
-    async fn find_token_owner(&self, token_hash: &[u8]) -> Result<Option<Uuid>>;
+    /// Revokes the refresh token row matching `token_hash` (including expired rows). Idempotent.
+    async fn revoke_refresh_token_by_hash(&self, token_hash: &[u8]) -> Result<()>;
     async fn cleanup_expired_tokens(&self, user_id: Uuid) -> Result<()>;
 }

--- a/data/src/db/postgres.rs
+++ b/data/src/db/postgres.rs
@@ -1140,24 +1140,14 @@ impl AuthRepository for PostgresMatchDB {
         Ok(())
     }
 
-    #[instrument(skip(self))]
-    async fn revoke_all_user_tokens(&self, user_id: Uuid) -> Result<()> {
-        sqlx::query("UPDATE refresh_token SET revoked = true WHERE user_id = $1")
-            .bind(user_id)
+    #[instrument(skip(self, token_hash))]
+    async fn revoke_refresh_token_by_hash(&self, token_hash: &[u8]) -> Result<()> {
+        sqlx::query("UPDATE refresh_token SET revoked = true WHERE token_hash = $1 AND revoked = false")
+            .bind(token_hash)
             .execute(&self.pool)
             .await?;
 
         Ok(())
-    }
-
-    #[instrument(skip(self, token_hash))]
-    async fn find_token_owner(&self, token_hash: &[u8]) -> Result<Option<Uuid>> {
-        let row: Option<(Uuid,)> = sqlx::query_as("SELECT user_id FROM refresh_token WHERE token_hash = $1")
-            .bind(token_hash)
-            .fetch_optional(&self.pool)
-            .await?;
-
-        Ok(row.map(|(user_id,)| user_id))
     }
 
     #[instrument(skip(self))]

--- a/server/src/auth.rs
+++ b/server/src/auth.rs
@@ -180,15 +180,11 @@ impl AuthServiceImpl {
             Status::unauthenticated("invalid or expired refresh token")
         })?;
 
-        // Reuse detection: if the token was already revoked, someone may have stolen it.
-        // Revoke ALL tokens for this user as a precaution.
+        // Reuse detection: token was already rotated or this session was logged out.
+        // Do not revoke other devices' sessions — only reject this request (same as unknown token).
         if row.revoked {
-            error!("Revoked refresh token reuse detected for user {}", row.user_id);
-            self.db.revoke_all_user_tokens(row.user_id).await.map_err(|e| {
-                error!("Failed to revoke all tokens for user {}: {e}", row.user_id);
-                Status::internal("failed to revoke tokens")
-            })?;
-            return Err(Status::unauthenticated("token reuse detected"));
+            info!("Rejected refresh using revoked token for user {}", row.user_id);
+            return Err(Status::unauthenticated("invalid or expired refresh token"));
         }
 
         // Revoke the old token
@@ -362,19 +358,11 @@ impl AuthService for AuthServiceImpl {
 
         let token_hash = hash_token(&req.refresh_token);
 
-        // Find the user who owns this token and revoke all their tokens
-        let user_id = self.db.find_token_owner(&token_hash).await.map_err(|e| {
-            error!("Failed to look up refresh token for logout: {e}");
+        // Revoke only this refresh token so other devices stay signed in.
+        self.db.revoke_refresh_token_by_hash(&token_hash).await.map_err(|e| {
+            error!("Failed to revoke refresh token for logout: {e}");
             Status::internal("failed to process logout")
         })?;
-
-        if let Some(user_id) = user_id {
-            self.db.revoke_all_user_tokens(user_id).await.map_err(|e| {
-                error!("Failed to revoke all tokens for user {user_id}: {e}");
-                Status::internal("failed to revoke tokens")
-            })?;
-            info!("Revoked all refresh tokens for user {user_id}");
-        }
 
         Ok(Response::new(LogoutResponse {}))
     }


### PR DESCRIPTION
## Scope logout and token revocation to individual sessions

Previously, both logout and revoked-token reuse detection would revoke **all** refresh tokens for a user, signing out every device simultaneously. This was overly aggressive and broke multi-device sessions.

### Changes

**Logout** now revokes only the specific refresh token provided in the request, leaving other active sessions untouched. The `find_token_owner` + `revoke_all_user_tokens` two-step is replaced by a single `revoke_refresh_token_by_hash` call that updates only the matching row.

**Reuse detection** (presenting an already-revoked token) no longer triggers a global revocation of all user tokens. The request is rejected with the same generic unauthenticated error as an unknown token, preventing an attacker from using a stolen revoked token as a denial-of-service vector against the legitimate user's other sessions.

**`revoke_refresh_token_by_hash`** replaces the removed `revoke_all_user_tokens` and `find_token_owner` trait methods. The underlying query is idempotent — it only updates rows where `revoked = false`, so calling it on an already-revoked or nonexistent token is a no-op.