### PR TITLE
fix: update Dioxus version reference in AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,6 +26,6 @@ SQLX_OFFLINE=true cargo test -p <crate>
 
 - The `data` crate uses `sqlx.toml` with `database-url-var = "ARENABUDDY_DATABASE_URL"` (not the standard `DATABASE_URL`). For offline mode set `SQLX_OFFLINE=true`.
 - Rust edition 2024 requires `rust-version = "1.94"`. The snapshot has stable 1.94+ and nightly installed.
-- The desktop app (`arenabuddy` crate) and web app (`web` crate) use Dioxus 0.7.3. Building them with `dx serve` requires the Dioxus CLI, but `cargo check`/`clippy`/`test` work without it.
+- The desktop app (`arenabuddy` crate) and web app (`web` crate) use Dioxus 0.7.7. Building them with `dx serve` requires the Dioxus CLI, but `cargo check`/`clippy`/`test` work without it.
 - The server requires PostgreSQL, Discord OAuth credentials, and a JWT secret to run. For compile/test, `SQLX_OFFLINE=true` is sufficient.
 - Integration tests for `arenabuddy_data` may attempt to start an embedded PostgreSQL; this is handled by the `postgresql_embedded` crate with the `bundled` feature.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Updates the Dioxus version reference in `AGENTS.md` from 0.7.3 to 0.7.7 to match the actual version specified in `Cargo.toml`.

This was discovered during development environment setup verification.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-89653def-3fbf-4682-affa-518de520b943"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-89653def-3fbf-4682-affa-518de520b943"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

