### PR TITLE
feat: add card table in PostgreSQL with CLI load-cards command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -164,7 +164,7 @@ dependencies = [
  "csv",
  "ctrlc",
  "dirs",
- "reqwest 0.13.2",
+ "reqwest 0.13.3",
  "rusqlite",
  "rustyline",
  "serde_json",
@@ -207,6 +207,7 @@ dependencies = [
  "chrono",
  "dirs",
  "postgresql_embedded",
+ "serde",
  "serde_json",
  "sqlx 0.9.0-alpha.1",
  "thiserror 2.0.18",
@@ -223,7 +224,7 @@ dependencies = [
  "arenabuddy_data",
  "chrono",
  "clap",
- "reqwest 0.13.2",
+ "reqwest 0.13.3",
  "scraper",
  "serde",
  "serde_json",
@@ -248,7 +249,7 @@ dependencies = [
  "opentelemetry-otlp",
  "opentelemetry_sdk",
  "rand 0.10.1",
- "reqwest 0.13.2",
+ "reqwest 0.13.3",
  "serde",
  "serde_json",
  "sha2 0.11.0",
@@ -1640,9 +1641,9 @@ dependencies = [
 
 [[package]]
 name = "dioxus"
-version = "0.7.6"
+version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14b5fd24c3d394e5a8cfc15b8319da5f853c9d27471a9f46ace0653761499740"
+checksum = "7c01ecf7ddbae18a419ad3d83c486101a85ffc5740ea09cdd0f09a30dc12170d"
 dependencies = [
  "dioxus-asset-resolver",
  "dioxus-cli-config",
@@ -1669,9 +1670,9 @@ dependencies = [
 
 [[package]]
 name = "dioxus-asset-resolver"
-version = "0.7.6"
+version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8b546050ecfc7fcd310be344b2f3a2a79f21554c5a9e8df28e7a07e9b36009b"
+checksum = "69387edbbc60c7cb93ad96d8cc7a22b49a76e21643380b89b1c49a78d347ff60"
 dependencies = [
  "dioxus-cli-config",
  "http",
@@ -1690,18 +1691,18 @@ dependencies = [
 
 [[package]]
 name = "dioxus-cli-config"
-version = "0.7.6"
+version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4ad73f0ff638cd27466d389cd57f0975f909b66130dc1c25d5212d4041e5352"
+checksum = "c000f584ddf608e2b272b3074bf11512a474eeeb2eb85a1915f276ce5c4a8615"
 dependencies = [
  "wasm-bindgen",
 ]
 
 [[package]]
 name = "dioxus-config-macro"
-version = "0.7.6"
+version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e004bc8b958031117d373db2b5e0ab9d7e763751de129dd36f00ef7e318333cd"
+checksum = "7637091592978fbfdb45a16b26bd99fd97fb1bd7e31c6a963530e00c022af321"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1709,15 +1710,15 @@ dependencies = [
 
 [[package]]
 name = "dioxus-config-macros"
-version = "0.7.6"
+version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "808a9994a9a2623e6b6890b6cc68def24bd669177ec4713684447fb46418c256"
+checksum = "54f9ed8fc1a215ad34bb8dbae42a4ea54efbcd26ca9006bbe5cca78e511bf25f"
 
 [[package]]
 name = "dioxus-core"
-version = "0.7.6"
+version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "247ed8d679a13232641f1c84ba22246623fae01320b4c22db225c0b4f2fa7398"
+checksum = "45887100ff0cf89abeb8b659808294fda48cd53f3b424e36407dedffcfea830b"
 dependencies = [
  "anyhow",
  "const_format",
@@ -1737,9 +1738,9 @@ dependencies = [
 
 [[package]]
 name = "dioxus-core-macro"
-version = "0.7.6"
+version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75fbe64029b90144041f8521300c7b3508e6c48caea3244de2ff5d1ade15390c"
+checksum = "370c63663dff0f24df5dfea643ca239283542c6b228a302f69b32e1d36762b7f"
 dependencies = [
  "convert_case 0.8.0",
  "dioxus-rsx",
@@ -1750,15 +1751,15 @@ dependencies = [
 
 [[package]]
 name = "dioxus-core-types"
-version = "0.7.6"
+version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cbfea5c8946e0745b254b5c33c515d81b3ba638f33c2a532ed06730392394d4d"
+checksum = "36963eab106b169737762f9cd5ee5fd97f585989dcb2d8e30a596e97a6999009"
 
 [[package]]
 name = "dioxus-desktop"
-version = "0.7.6"
+version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00c82f695d1214e41482badc0f8d0057b256c077a2827ade637f925f4097f1f6"
+checksum = "662cd78c73ca3f17346adbf2d64757df40dd0ce20536c05123097fd31828d2bd"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1813,9 +1814,9 @@ dependencies = [
 
 [[package]]
 name = "dioxus-devtools"
-version = "0.7.6"
+version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08d30370fa78266aed3f3d9119dea2de9e92a0348941dbfa777f7a669f2ea375"
+checksum = "2349cedbdf1b429df1f1bea61fdee0ad3dae7b2548eedfbeca82710122a57da0"
 dependencies = [
  "dioxus-cli-config",
  "dioxus-core",
@@ -1831,9 +1832,9 @@ dependencies = [
 
 [[package]]
 name = "dioxus-devtools-types"
-version = "0.7.6"
+version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3907a2b61cf56039f047da6a37317a03d9e15411753bc40e5e34a27e405ac320"
+checksum = "0ab9b0f7565d1916b70915f59b89ea8054ef0a9d67a364a32bbee68ef5f3818d"
 dependencies = [
  "dioxus-core",
  "serde",
@@ -1842,9 +1843,9 @@ dependencies = [
 
 [[package]]
 name = "dioxus-document"
-version = "0.7.6"
+version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3b75a1809af7c13546ae4487c8b02ab80cc4d059e7db5a5d090374ceaa71d5b"
+checksum = "37e3a5bec7ffc999ff23446a487eb5cd86111d1574a23533dd3f8b3c69a53a22"
 dependencies = [
  "dioxus-core",
  "dioxus-core-macro",
@@ -1861,9 +1862,9 @@ dependencies = [
 
 [[package]]
 name = "dioxus-fullstack"
-version = "0.7.6"
+version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8ee56dd65fbf1222fa6a2749c3f821df28facf1832854b43d480b547a096f6d"
+checksum = "37f0558edb88af5ad47275ae36a7f06317163ba482db377c26d7d8590b5cd0f6"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -1918,9 +1919,9 @@ dependencies = [
 
 [[package]]
 name = "dioxus-fullstack-core"
-version = "0.7.6"
+version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d40d33a447cb158acdb61787b2ff52dd8a0f9a9f20e95e5c5fe9873f01c2b55b"
+checksum = "cc634b28b4b1e3eab1e8df4f98510e2d2fa39d686321467f977213155e86ed2b"
 dependencies = [
  "anyhow",
  "axum-core",
@@ -1946,9 +1947,9 @@ dependencies = [
 
 [[package]]
 name = "dioxus-fullstack-macro"
-version = "0.7.6"
+version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c06eb66bce50d5f47b793e6af5fc2e0a511bf2b4fa2423cf86e35023d8f17e6"
+checksum = "85a8fe7da549859fae00c7f4bf11a2aab734ae7ef6f98f280dce9bea1f3326ec"
 dependencies = [
  "const_format",
  "convert_case 0.8.0",
@@ -1960,9 +1961,9 @@ dependencies = [
 
 [[package]]
 name = "dioxus-history"
-version = "0.7.6"
+version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1d8024afd482956eadae2c43d0b1e73e584adb724ac09be87f268d52002387b"
+checksum = "1a15232302d1933015fcf2d6fe9e286ad36f6e9c205a546089a0f326023bb0d2"
 dependencies = [
  "dioxus-core",
  "tracing",
@@ -1970,9 +1971,9 @@ dependencies = [
 
 [[package]]
 name = "dioxus-hooks"
-version = "0.7.6"
+version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "233b5e168a7c38c4bf96d0f390221a72a5a28bb31ce2dcf6d2af879dc561ef42"
+checksum = "4534f91cf6305204b948bdec130076ac9ecc7c22faab29475b76870558bf73ea"
 dependencies = [
  "dioxus-core",
  "dioxus-signals",
@@ -1986,9 +1987,9 @@ dependencies = [
 
 [[package]]
 name = "dioxus-html"
-version = "0.7.6"
+version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4abf4ad27eee650d1ab8ebe13591e8b0ee595fa5a5dd236be13a5b7b3fab678d"
+checksum = "e03d6ad4040b667f2b2eefcb678840e630938c09bf9ec39b04ea4d1d96d90d44"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2013,9 +2014,9 @@ dependencies = [
 
 [[package]]
 name = "dioxus-html-internal-macro"
-version = "0.7.6"
+version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "025e107e677f790f4ed648a189e36f51ae014e5341902b97313e4eae626cffa2"
+checksum = "584e2772127ab00f0d5e1d4d9795f39fecebc828ece0b7a02349d438bc1b1ce7"
 dependencies = [
  "convert_case 0.8.0",
  "proc-macro2",
@@ -2025,9 +2026,9 @@ dependencies = [
 
 [[package]]
 name = "dioxus-interpreter-js"
-version = "0.7.6"
+version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57caa76427d8ec4105ccca44ff8c511055688af732a094b9fe9ef3547d2a11b2"
+checksum = "11999d6eb5bb179a9512dad30e5de408aab66f2cb65de9098c9fbe02927e2978"
 dependencies = [
  "dioxus-core",
  "dioxus-core-types",
@@ -2045,9 +2046,9 @@ dependencies = [
 
 [[package]]
 name = "dioxus-logger"
-version = "0.7.6"
+version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0cbbee192b1b12fccb444a5b04d809710cfce4d27b792129fea6c845fae7f329"
+checksum = "a28ccdfe36d2cb830a2784e40f7e6f7199805a2c6da99bd65b1ca308f11aed28"
 dependencies = [
  "dioxus-cli-config",
  "tracing",
@@ -2057,9 +2058,9 @@ dependencies = [
 
 [[package]]
 name = "dioxus-router"
-version = "0.7.6"
+version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecdb19d7a1489ba252be9b3a07f9db92814020eb4ba8c1306f04242a44d17e66"
+checksum = "38e47f62d680429badfcb99bf5dec17ee92b0cb9623f264e36bc003a1359bfdc"
 dependencies = [
  "dioxus-cli-config",
  "dioxus-core",
@@ -2077,9 +2078,9 @@ dependencies = [
 
 [[package]]
 name = "dioxus-router-macro"
-version = "0.7.6"
+version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b525ab775585f1dc4850178de9d0cb6bb37f7b9c1a1a0c121eab7449d7021480"
+checksum = "6f83fb667d27e256f8c9eca49963fbace66a8722cb64ee15a10ffc97d092357e"
 dependencies = [
  "base16",
  "digest 0.10.7",
@@ -2092,9 +2093,9 @@ dependencies = [
 
 [[package]]
 name = "dioxus-rsx"
-version = "0.7.6"
+version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37fb07e40e9734946511659668ea3675ed214b60889e7aa7f0a5a85271518475"
+checksum = "2106afda239a4c7c22ffa1ca19117011225fc1c735c139c0a5b765996aa8bb1d"
 dependencies = [
  "proc-macro2",
  "proc-macro2-diagnostics",
@@ -2105,9 +2106,9 @@ dependencies = [
 
 [[package]]
 name = "dioxus-signals"
-version = "0.7.6"
+version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5393fd579f42c6547bf47ec0a2dedf2a366cd541d31deedc1059a096e6c35798"
+checksum = "3705754f5e043deec9fc7af0d159f18e5b21c02c47d255c7e477f31368f0b6d2"
 dependencies = [
  "dioxus-core",
  "futures-channel",
@@ -2121,9 +2122,9 @@ dependencies = [
 
 [[package]]
 name = "dioxus-stores"
-version = "0.7.6"
+version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1c59f52e8194439604dd35f8c540456c22b4a4b076930e424d0289f98ea3cb4"
+checksum = "64bec7b21c86b1360ec965a07a53a2c96b7caee3465049e1c299a45024e87614"
 dependencies = [
  "dioxus-core",
  "dioxus-signals",
@@ -2133,9 +2134,9 @@ dependencies = [
 
 [[package]]
 name = "dioxus-stores-macro"
-version = "0.7.6"
+version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "737600865572cecf60ff934f88252bd4144f4ca189e0e570b7a780e8f0e01a1f"
+checksum = "40a5875e9f890f27b1cc3e5b56c1e23601211470315a1fb8627c4ca4f3b2be9a"
 dependencies = [
  "convert_case 0.8.0",
  "proc-macro2",
@@ -2145,9 +2146,9 @@ dependencies = [
 
 [[package]]
 name = "dioxus-web"
-version = "0.7.6"
+version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "176eb0a5ee8251203a816b413a64fdc014b43e53d4245f769b1b0c2035b88ac3"
+checksum = "bc0a0be76b404e8242a597db0fb239d05f8dee4e7856bc1fc7144f7e244822fd"
 dependencies = [
  "dioxus-cli-config",
  "dioxus-core",
@@ -2913,9 +2914,9 @@ dependencies = [
 
 [[package]]
 name = "generational-box"
-version = "0.7.6"
+version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c68d74be1fbe3bba37604bdfd61403f26af9f6324cf325053abd89d60c22e799"
+checksum = "8cd0d825b8d339701ad330dbcd6399519ced4d143484954daf6e3185dace4f77"
 dependencies = [
  "parking_lot",
  "tracing",
@@ -4113,9 +4114,9 @@ dependencies = [
 
 [[package]]
 name = "lazy-js-bundle"
-version = "0.7.6"
+version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebbde2c5796719fbd82d6b8ec0be3dacf1f70c2876dee0f2c001632794d6641f"
+checksum = "ccafada6c9541db44db758619236f2748f6e1bdaa84d04ded858567cd1e89321"
 
 [[package]]
 name = "lazy_static"
@@ -4328,9 +4329,9 @@ dependencies = [
 
 [[package]]
 name = "manganis"
-version = "0.7.6"
+version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e06225f29a781d86afdfafa562de09621f2ace377136ae2ae9ca9e72a29b920"
+checksum = "8bfcf56309de35b48b8780ea097ace5c3b773a617b52edc49dfc9a63a7d9dc43"
 dependencies = [
  "const-serialize 0.7.2",
  "const-serialize 0.8.0-alpha.0",
@@ -4344,9 +4345,9 @@ dependencies = [
 
 [[package]]
 name = "manganis-core"
-version = "0.7.6"
+version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "774ddc382b4fb30f3fdcf2418131cbac5e6111f00e6c7ddf9e598ef3b2b4cd91"
+checksum = "a24d6be68f594495aea60850a284029d585d7b7839b26096c1b6d758f8518648"
 dependencies = [
  "const-serialize 0.7.2",
  "const-serialize 0.8.0-alpha.0",
@@ -4358,9 +4359,9 @@ dependencies = [
 
 [[package]]
 name = "manganis-macro"
-version = "0.7.6"
+version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "731c83c89d831f341fb46eba0aefdfb3433f77a3f78a8b08d9d88746613a8f8b"
+checksum = "5e782a10318d707c0833e31876ded8acf91287eee0010af8392559af614c7226"
 dependencies = [
  "dunce",
  "macro-string",
@@ -5504,7 +5505,7 @@ dependencies = [
  "futures-util",
  "hex",
  "regex-lite",
- "reqwest 0.13.2",
+ "reqwest 0.13.3",
  "reqwest-middleware",
  "reqwest-retry",
  "reqwest-tracing",
@@ -6268,9 +6269,9 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
-version = "0.13.2"
+version = "0.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab3f43e3283ab1488b624b44b0e988d0acea0b3214e694730a055cb6b2efa801"
+checksum = "62e0021ea2c22aed41653bc7e1419abb2c97e038ff2c33d0e1309e49a97deec0"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -6322,7 +6323,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "http",
- "reqwest 0.13.2",
+ "reqwest 0.13.3",
  "serde",
  "thiserror 2.0.18",
  "tower-service",
@@ -6340,7 +6341,7 @@ dependencies = [
  "getrandom 0.2.17",
  "http",
  "hyper",
- "reqwest 0.13.2",
+ "reqwest 0.13.3",
  "reqwest-middleware",
  "retry-policies",
  "thiserror 2.0.18",
@@ -6360,7 +6361,7 @@ dependencies = [
  "getrandom 0.2.17",
  "http",
  "matchit",
- "reqwest 0.13.2",
+ "reqwest 0.13.3",
  "reqwest-middleware",
  "tracing",
 ]
@@ -7602,9 +7603,9 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "subsecond"
-version = "0.7.6"
+version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "feae81a4a7ca6d0bcf70c385a43b7dbacbff527f0805cb0a4043ce2c2c559a2c"
+checksum = "9cc79674bd55726e6b123204403389400229a95fe4a3b2c5453dada70b06ca95"
 dependencies = [
  "js-sys",
  "libc",
@@ -7621,9 +7622,9 @@ dependencies = [
 
 [[package]]
 name = "subsecond-types"
-version = "0.7.6"
+version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85256ee192cbdf00473e48e6133863b125dd4f772fddfbc97287ec7a61458c25"
+checksum = "e9798bfed58797aed51c672aa99810aac30a50d3120ecfdcf28c13784e9a8f1c"
 dependencies = [
  "serde",
 ]

--- a/cli/src/commands/definitions.rs
+++ b/cli/src/commands/definitions.rs
@@ -65,6 +65,15 @@ pub enum Commands {
         command: MetagameCommands,
     },
 
+    /// Load card data into the database from a protobuf file or embedded defaults
+    LoadCards {
+        #[arg(short, long, help = "Path to cards protobuf file (uses embedded default if omitted)")]
+        cards_db: Option<PathBuf>,
+
+        #[arg(long, env = "ARENABUDDY_DATABASE_URL", help = "PostgreSQL database URL")]
+        db: String,
+    },
+
     /// Generate a structured event log from a Player.log file
     EventLog {
         #[arg(short, long, help = "Location of Player.log file")]

--- a/cli/src/commands/load_cards.rs
+++ b/cli/src/commands/load_cards.rs
@@ -1,0 +1,29 @@
+use std::path::PathBuf;
+
+use arenabuddy_core::cards::CardsDatabase;
+use arenabuddy_data::{ArenabuddyRepository, CardRepository, MatchDB};
+use tracing::info;
+
+use crate::Result;
+
+pub async fn execute(cards_db_path: Option<&PathBuf>, db_url: &str) -> Result<()> {
+    let cards_db = if let Some(path) = cards_db_path {
+        info!("Loading cards from: {:?}", path);
+        CardsDatabase::new(path)?
+    } else {
+        info!("Loading cards from embedded default database");
+        CardsDatabase::default()
+    };
+
+    let card_count = cards_db.len();
+    info!("Found {} cards to load", card_count);
+
+    let db = MatchDB::new(Some(db_url), CardsDatabase::default()).await?;
+    db.init().await?;
+
+    let cards: Vec<_> = cards_db.values().cloned().collect();
+    db.load_cards(&cards).await?;
+
+    info!("Successfully loaded {} cards into PostgreSQL", card_count);
+    Ok(())
+}

--- a/cli/src/commands/mod.rs
+++ b/cli/src/commands/mod.rs
@@ -1,5 +1,6 @@
 pub mod definitions;
 pub mod event_log;
+pub mod load_cards;
 pub mod metagame;
 pub mod parse;
 pub mod repl;

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -68,6 +68,10 @@ pub async fn run() -> Result<()> {
             commands::metagame::execute(command).await?;
         }
 
+        Commands::LoadCards { cards_db, db } => {
+            commands::load_cards::execute(cards_db.as_ref(), db).await?;
+        }
+
         Commands::EventLog {
             player_log,
             cards_db,

--- a/data/Cargo.toml
+++ b/data/Cargo.toml
@@ -16,6 +16,7 @@ async-trait = { workspace = true }
 chrono = { workspace = true, features = ["serde"] }
 dirs = { workspace = true }
 postgresql_embedded = { workspace = true, features = ["bundled"] }
+serde = { workspace = true }
 serde_json = { workspace = true }
 sqlx = { workspace = true, features = [
     "chrono",

--- a/data/migrations/postgres/20260520000000_add_card_table.sql
+++ b/data/migrations/postgres/20260520000000_add_card_table.sql
@@ -1,0 +1,18 @@
+CREATE TABLE IF NOT EXISTS card (
+    arena_id BIGINT PRIMARY KEY,
+    name TEXT NOT NULL,
+    set_code TEXT NOT NULL,
+    lang TEXT NOT NULL DEFAULT 'en',
+    image_uri TEXT NOT NULL DEFAULT '',
+    mana_cost TEXT NOT NULL DEFAULT '',
+    cmc INTEGER NOT NULL DEFAULT 0,
+    type_line TEXT NOT NULL DEFAULT '',
+    layout TEXT NOT NULL DEFAULT 'normal',
+    colors TEXT NOT NULL DEFAULT '[]',
+    color_identity TEXT NOT NULL DEFAULT '[]',
+    card_faces TEXT NOT NULL DEFAULT '[]',
+    updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE INDEX IF NOT EXISTS card_name_idx ON card (name);
+CREATE INDEX IF NOT EXISTS card_set_code_idx ON card (set_code);

--- a/data/src/db/card_postgres.rs
+++ b/data/src/db/card_postgres.rs
@@ -1,0 +1,174 @@
+use arenabuddy_core::models::{Card, CardFace};
+use sqlx::FromRow;
+use tracing::info;
+
+use super::{card_repository::CardRepository, postgres::PostgresMatchDB};
+use crate::Result;
+
+#[derive(FromRow)]
+struct CardRow {
+    arena_id: i64,
+    name: String,
+    set_code: String,
+    lang: String,
+    image_uri: String,
+    mana_cost: String,
+    cmc: i32,
+    type_line: String,
+    layout: String,
+    colors: String,
+    color_identity: String,
+    card_faces: String,
+}
+
+impl CardRow {
+    fn into_card(self) -> Card {
+        let colors: Vec<String> = serde_json::from_str(&self.colors).unwrap_or_default();
+        let color_identity: Vec<String> = serde_json::from_str(&self.color_identity).unwrap_or_default();
+        let card_faces: Vec<CardFaceJson> = serde_json::from_str(&self.card_faces).unwrap_or_default();
+
+        Card {
+            id: self.arena_id,
+            name: self.name,
+            set: self.set_code,
+            lang: self.lang,
+            image_uri: self.image_uri,
+            mana_cost: self.mana_cost,
+            cmc: self.cmc,
+            type_line: self.type_line,
+            layout: self.layout,
+            colors,
+            color_identity,
+            card_faces: card_faces.into_iter().map(CardFaceJson::into_card_face).collect(),
+        }
+    }
+}
+
+#[derive(serde::Serialize, serde::Deserialize)]
+struct CardFaceJson {
+    name: String,
+    type_line: String,
+    mana_cost: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    image_uri: Option<String>,
+    colors: Vec<String>,
+}
+
+impl CardFaceJson {
+    fn from_card_face(face: &CardFace) -> Self {
+        Self {
+            name: face.name.clone(),
+            type_line: face.type_line.clone(),
+            mana_cost: face.mana_cost.clone(),
+            image_uri: face.image_uri.clone(),
+            colors: face.colors.clone(),
+        }
+    }
+
+    fn into_card_face(self) -> CardFace {
+        CardFace {
+            name: self.name,
+            type_line: self.type_line,
+            mana_cost: self.mana_cost,
+            image_uri: self.image_uri,
+            colors: self.colors,
+        }
+    }
+}
+
+const BATCH_SIZE: usize = 1000;
+
+#[async_trait::async_trait]
+impl CardRepository for PostgresMatchDB {
+    async fn load_cards(&self, cards: &[Card]) -> Result<()> {
+        let mut tx = self.pool().begin().await?;
+
+        sqlx::query("TRUNCATE TABLE card").execute(&mut *tx).await?;
+
+        for chunk in cards.chunks(BATCH_SIZE) {
+            let arena_ids: Vec<i64> = chunk.iter().map(|c| c.id).collect();
+            let names: Vec<&str> = chunk.iter().map(|c| c.name.as_str()).collect();
+            let set_codes: Vec<&str> = chunk.iter().map(|c| c.set.as_str()).collect();
+            let langs: Vec<&str> = chunk.iter().map(|c| c.lang.as_str()).collect();
+            let image_uris: Vec<&str> = chunk.iter().map(|c| c.image_uri.as_str()).collect();
+            let mana_costs: Vec<&str> = chunk.iter().map(|c| c.mana_cost.as_str()).collect();
+            let cmcs: Vec<i32> = chunk.iter().map(|c| c.cmc).collect();
+            let type_lines: Vec<&str> = chunk.iter().map(|c| c.type_line.as_str()).collect();
+            let layouts: Vec<&str> = chunk.iter().map(|c| c.layout.as_str()).collect();
+
+            let colors: Vec<String> = chunk
+                .iter()
+                .map(|c| serde_json::to_string(&c.colors).unwrap_or_else(|_| "[]".to_string()))
+                .collect();
+
+            let color_identities: Vec<String> = chunk
+                .iter()
+                .map(|c| serde_json::to_string(&c.color_identity).unwrap_or_else(|_| "[]".to_string()))
+                .collect();
+
+            let card_faces_json: Vec<String> = chunk
+                .iter()
+                .map(|c| {
+                    let faces: Vec<CardFaceJson> = c.card_faces.iter().map(CardFaceJson::from_card_face).collect();
+                    serde_json::to_string(&faces).unwrap_or_else(|_| "[]".to_string())
+                })
+                .collect();
+
+            sqlx::query(
+                r"INSERT INTO card (arena_id, name, set_code, lang, image_uri, mana_cost, cmc, type_line, layout, colors, color_identity, card_faces)
+                  SELECT * FROM UNNEST(
+                      $1::bigint[], $2::text[], $3::text[], $4::text[], $5::text[],
+                      $6::text[], $7::integer[], $8::text[], $9::text[], $10::text[],
+                      $11::text[], $12::text[]
+                  )",
+            )
+            .bind(&arena_ids)
+            .bind(&names)
+            .bind(&set_codes)
+            .bind(&langs)
+            .bind(&image_uris)
+            .bind(&mana_costs)
+            .bind(&cmcs)
+            .bind(&type_lines)
+            .bind(&layouts)
+            .bind(&colors)
+            .bind(&color_identities)
+            .bind(&card_faces_json)
+            .execute(&mut *tx)
+            .await?;
+        }
+
+        tx.commit().await?;
+        info!("Loaded {} cards into database", cards.len());
+        Ok(())
+    }
+
+    async fn get_card(&self, arena_id: i64) -> Result<Option<Card>> {
+        let row: Option<CardRow> = sqlx::query_as(
+            "SELECT arena_id, name, set_code, lang, image_uri, mana_cost, cmc, type_line, layout, colors, color_identity, card_faces FROM card WHERE arena_id = $1",
+        )
+        .bind(arena_id)
+        .fetch_optional(self.pool())
+        .await?;
+
+        Ok(row.map(CardRow::into_card))
+    }
+
+    async fn get_cards(&self, arena_ids: &[i64]) -> Result<Vec<Card>> {
+        let rows: Vec<CardRow> = sqlx::query_as(
+            "SELECT arena_id, name, set_code, lang, image_uri, mana_cost, cmc, type_line, layout, colors, color_identity, card_faces FROM card WHERE arena_id = ANY($1)",
+        )
+        .bind(arena_ids)
+        .fetch_all(self.pool())
+        .await?;
+
+        Ok(rows.into_iter().map(CardRow::into_card).collect())
+    }
+
+    async fn card_count(&self) -> Result<i64> {
+        let row: (i64,) = sqlx::query_as("SELECT COUNT(*) FROM card")
+            .fetch_one(self.pool())
+            .await?;
+        Ok(row.0)
+    }
+}

--- a/data/src/db/card_repository.rs
+++ b/data/src/db/card_repository.rs
@@ -1,0 +1,11 @@
+use arenabuddy_core::models::Card;
+
+use crate::Result;
+
+#[async_trait::async_trait]
+pub trait CardRepository: Send + Sync {
+    async fn load_cards(&self, cards: &[Card]) -> Result<()>;
+    async fn get_card(&self, arena_id: i64) -> Result<Option<Card>>;
+    async fn get_cards(&self, arena_ids: &[i64]) -> Result<Vec<Card>>;
+    async fn card_count(&self) -> Result<i64>;
+}

--- a/data/src/db/mod.rs
+++ b/data/src/db/mod.rs
@@ -1,4 +1,6 @@
 pub mod auth_repository;
+mod card_postgres;
+pub mod card_repository;
 pub mod debug_repository;
 pub mod metagame_models;
 mod metagame_postgres;
@@ -8,6 +10,7 @@ mod postgres;
 mod repository;
 
 pub use auth_repository::AuthRepository;
+pub use card_repository::CardRepository;
 pub use debug_repository::DebugRepository;
 pub use metagame_repository::MetagameRepository;
 pub use models::{AppUser, RefreshToken};

--- a/data/src/lib.rs
+++ b/data/src/lib.rs
@@ -3,8 +3,8 @@ mod errors;
 mod storage;
 
 pub use db::{
-    AppUser, ArenabuddyRepository, AuthRepository, DebugRepository, MatchDB, MetagameRepository, RefreshToken,
-    metagame_models, metagame_repository,
+    AppUser, ArenabuddyRepository, AuthRepository, CardRepository, DebugRepository, MatchDB, MetagameRepository,
+    RefreshToken, metagame_models, metagame_repository,
 };
 pub use errors::{Error, Result};
 pub use storage::DirectoryStorage;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a `card` table to PostgreSQL so card metadata is joinable with match, deck, draft, and opponent data. Cards are easily overwritable since the load operation atomically replaces all rows (TRUNCATE + batch INSERT in a single transaction).

## Changes

### New migration: `20260520000000_add_card_table.sql`
Creates the `card` table with:
- `arena_id BIGINT PRIMARY KEY` — MTGA GrpId, matching `Card.id` and the arena IDs stored in `deck.deck_cards`, `opponent_deck.cards`, `draft_pack.cards`, etc.
- Full card metadata: `name`, `set_code`, `lang`, `image_uri`, `mana_cost`, `cmc`, `type_line`, `layout`
- `colors`, `color_identity`, `card_faces` as JSON text (consistent with existing patterns)
- Indexes on `name` and `set_code`

### New trait: `CardRepository`
- `load_cards(&[Card])` — atomic full replacement via TRUNCATE + UNNEST batch inserts (1000 rows/batch)
- `get_card(arena_id)` — single card lookup
- `get_cards(&[arena_id])` — bulk lookup via `ANY($1)`
- `card_count()` — total card count

### New CLI command: `load-cards`
```bash
# Load from embedded default card database
arenabuddyctl load-cards --db postgresql://...

# Load from a scraped .pb file
arenabuddyctl load-cards --cards-db ./cards.pb --db postgresql://...

# Uses ARENABUDDY_DATABASE_URL env var
ARENABUDDY_DATABASE_URL=postgresql://... arenabuddyctl load-cards
```

## Example join queries

Once cards are loaded, they're directly joinable with existing match data:

```sql
-- Join deck arena IDs with card metadata
SELECT c.name, c.mana_cost, c.type_line
FROM deck d,
     LATERAL jsonb_array_elements_text(d.deck_cards::jsonb) AS aid
JOIN card c ON c.arena_id = aid::bigint
WHERE d.match_id = '...';

-- Look up opponent's cards with full metadata
SELECT c.name, c.mana_cost, c.colors
FROM opponent_deck od,
     LATERAL jsonb_array_elements_text(od.cards::jsonb) AS aid
JOIN card c ON c.arena_id = aid::bigint
WHERE od.match_id = '...';
```

## Testing

Verified end-to-end:

[card_load_verification.log](https://cursor.com/agents/bc-89653def-3fbf-4682-affa-518de520b943/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fcard_load_verification.log)

- 18,183 cards loaded from embedded default in ~200ms
- Idempotent reload produces identical results (atomic TRUNCATE + INSERT)
- All existing tests pass
- `cargo check`, `cargo clippy`, `cargo fmt --check` all clean

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-89653def-3fbf-4682-affa-518de520b943"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-89653def-3fbf-4682-affa-518de520b943"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

