### PR TITLE
feat: add `deck show` CLI command and bump dioxus/reqwest dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -164,7 +164,7 @@ dependencies = [
  "csv",
  "ctrlc",
  "dirs",
- "reqwest 0.13.2",
+ "reqwest 0.13.3",
  "rusqlite",
  "rustyline",
  "serde_json",
@@ -223,7 +223,7 @@ dependencies = [
  "arenabuddy_data",
  "chrono",
  "clap",
- "reqwest 0.13.2",
+ "reqwest 0.13.3",
  "scraper",
  "serde",
  "serde_json",
@@ -248,7 +248,7 @@ dependencies = [
  "opentelemetry-otlp",
  "opentelemetry_sdk",
  "rand 0.10.1",
- "reqwest 0.13.2",
+ "reqwest 0.13.3",
  "serde",
  "serde_json",
  "sha2 0.11.0",
@@ -1640,9 +1640,9 @@ dependencies = [
 
 [[package]]
 name = "dioxus"
-version = "0.7.6"
+version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14b5fd24c3d394e5a8cfc15b8319da5f853c9d27471a9f46ace0653761499740"
+checksum = "7c01ecf7ddbae18a419ad3d83c486101a85ffc5740ea09cdd0f09a30dc12170d"
 dependencies = [
  "dioxus-asset-resolver",
  "dioxus-cli-config",
@@ -1669,9 +1669,9 @@ dependencies = [
 
 [[package]]
 name = "dioxus-asset-resolver"
-version = "0.7.6"
+version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8b546050ecfc7fcd310be344b2f3a2a79f21554c5a9e8df28e7a07e9b36009b"
+checksum = "69387edbbc60c7cb93ad96d8cc7a22b49a76e21643380b89b1c49a78d347ff60"
 dependencies = [
  "dioxus-cli-config",
  "http",
@@ -1690,18 +1690,18 @@ dependencies = [
 
 [[package]]
 name = "dioxus-cli-config"
-version = "0.7.6"
+version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4ad73f0ff638cd27466d389cd57f0975f909b66130dc1c25d5212d4041e5352"
+checksum = "c000f584ddf608e2b272b3074bf11512a474eeeb2eb85a1915f276ce5c4a8615"
 dependencies = [
  "wasm-bindgen",
 ]
 
 [[package]]
 name = "dioxus-config-macro"
-version = "0.7.6"
+version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e004bc8b958031117d373db2b5e0ab9d7e763751de129dd36f00ef7e318333cd"
+checksum = "7637091592978fbfdb45a16b26bd99fd97fb1bd7e31c6a963530e00c022af321"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1709,15 +1709,15 @@ dependencies = [
 
 [[package]]
 name = "dioxus-config-macros"
-version = "0.7.6"
+version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "808a9994a9a2623e6b6890b6cc68def24bd669177ec4713684447fb46418c256"
+checksum = "54f9ed8fc1a215ad34bb8dbae42a4ea54efbcd26ca9006bbe5cca78e511bf25f"
 
 [[package]]
 name = "dioxus-core"
-version = "0.7.6"
+version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "247ed8d679a13232641f1c84ba22246623fae01320b4c22db225c0b4f2fa7398"
+checksum = "45887100ff0cf89abeb8b659808294fda48cd53f3b424e36407dedffcfea830b"
 dependencies = [
  "anyhow",
  "const_format",
@@ -1737,9 +1737,9 @@ dependencies = [
 
 [[package]]
 name = "dioxus-core-macro"
-version = "0.7.6"
+version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75fbe64029b90144041f8521300c7b3508e6c48caea3244de2ff5d1ade15390c"
+checksum = "370c63663dff0f24df5dfea643ca239283542c6b228a302f69b32e1d36762b7f"
 dependencies = [
  "convert_case 0.8.0",
  "dioxus-rsx",
@@ -1750,15 +1750,15 @@ dependencies = [
 
 [[package]]
 name = "dioxus-core-types"
-version = "0.7.6"
+version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cbfea5c8946e0745b254b5c33c515d81b3ba638f33c2a532ed06730392394d4d"
+checksum = "36963eab106b169737762f9cd5ee5fd97f585989dcb2d8e30a596e97a6999009"
 
 [[package]]
 name = "dioxus-desktop"
-version = "0.7.6"
+version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00c82f695d1214e41482badc0f8d0057b256c077a2827ade637f925f4097f1f6"
+checksum = "662cd78c73ca3f17346adbf2d64757df40dd0ce20536c05123097fd31828d2bd"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1813,9 +1813,9 @@ dependencies = [
 
 [[package]]
 name = "dioxus-devtools"
-version = "0.7.6"
+version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08d30370fa78266aed3f3d9119dea2de9e92a0348941dbfa777f7a669f2ea375"
+checksum = "2349cedbdf1b429df1f1bea61fdee0ad3dae7b2548eedfbeca82710122a57da0"
 dependencies = [
  "dioxus-cli-config",
  "dioxus-core",
@@ -1831,9 +1831,9 @@ dependencies = [
 
 [[package]]
 name = "dioxus-devtools-types"
-version = "0.7.6"
+version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3907a2b61cf56039f047da6a37317a03d9e15411753bc40e5e34a27e405ac320"
+checksum = "0ab9b0f7565d1916b70915f59b89ea8054ef0a9d67a364a32bbee68ef5f3818d"
 dependencies = [
  "dioxus-core",
  "serde",
@@ -1842,9 +1842,9 @@ dependencies = [
 
 [[package]]
 name = "dioxus-document"
-version = "0.7.6"
+version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3b75a1809af7c13546ae4487c8b02ab80cc4d059e7db5a5d090374ceaa71d5b"
+checksum = "37e3a5bec7ffc999ff23446a487eb5cd86111d1574a23533dd3f8b3c69a53a22"
 dependencies = [
  "dioxus-core",
  "dioxus-core-macro",
@@ -1861,9 +1861,9 @@ dependencies = [
 
 [[package]]
 name = "dioxus-fullstack"
-version = "0.7.6"
+version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8ee56dd65fbf1222fa6a2749c3f821df28facf1832854b43d480b547a096f6d"
+checksum = "37f0558edb88af5ad47275ae36a7f06317163ba482db377c26d7d8590b5cd0f6"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -1918,9 +1918,9 @@ dependencies = [
 
 [[package]]
 name = "dioxus-fullstack-core"
-version = "0.7.6"
+version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d40d33a447cb158acdb61787b2ff52dd8a0f9a9f20e95e5c5fe9873f01c2b55b"
+checksum = "cc634b28b4b1e3eab1e8df4f98510e2d2fa39d686321467f977213155e86ed2b"
 dependencies = [
  "anyhow",
  "axum-core",
@@ -1946,9 +1946,9 @@ dependencies = [
 
 [[package]]
 name = "dioxus-fullstack-macro"
-version = "0.7.6"
+version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c06eb66bce50d5f47b793e6af5fc2e0a511bf2b4fa2423cf86e35023d8f17e6"
+checksum = "85a8fe7da549859fae00c7f4bf11a2aab734ae7ef6f98f280dce9bea1f3326ec"
 dependencies = [
  "const_format",
  "convert_case 0.8.0",
@@ -1960,9 +1960,9 @@ dependencies = [
 
 [[package]]
 name = "dioxus-history"
-version = "0.7.6"
+version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1d8024afd482956eadae2c43d0b1e73e584adb724ac09be87f268d52002387b"
+checksum = "1a15232302d1933015fcf2d6fe9e286ad36f6e9c205a546089a0f326023bb0d2"
 dependencies = [
  "dioxus-core",
  "tracing",
@@ -1970,9 +1970,9 @@ dependencies = [
 
 [[package]]
 name = "dioxus-hooks"
-version = "0.7.6"
+version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "233b5e168a7c38c4bf96d0f390221a72a5a28bb31ce2dcf6d2af879dc561ef42"
+checksum = "4534f91cf6305204b948bdec130076ac9ecc7c22faab29475b76870558bf73ea"
 dependencies = [
  "dioxus-core",
  "dioxus-signals",
@@ -1986,9 +1986,9 @@ dependencies = [
 
 [[package]]
 name = "dioxus-html"
-version = "0.7.6"
+version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4abf4ad27eee650d1ab8ebe13591e8b0ee595fa5a5dd236be13a5b7b3fab678d"
+checksum = "e03d6ad4040b667f2b2eefcb678840e630938c09bf9ec39b04ea4d1d96d90d44"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2013,9 +2013,9 @@ dependencies = [
 
 [[package]]
 name = "dioxus-html-internal-macro"
-version = "0.7.6"
+version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "025e107e677f790f4ed648a189e36f51ae014e5341902b97313e4eae626cffa2"
+checksum = "584e2772127ab00f0d5e1d4d9795f39fecebc828ece0b7a02349d438bc1b1ce7"
 dependencies = [
  "convert_case 0.8.0",
  "proc-macro2",
@@ -2025,9 +2025,9 @@ dependencies = [
 
 [[package]]
 name = "dioxus-interpreter-js"
-version = "0.7.6"
+version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57caa76427d8ec4105ccca44ff8c511055688af732a094b9fe9ef3547d2a11b2"
+checksum = "11999d6eb5bb179a9512dad30e5de408aab66f2cb65de9098c9fbe02927e2978"
 dependencies = [
  "dioxus-core",
  "dioxus-core-types",
@@ -2045,9 +2045,9 @@ dependencies = [
 
 [[package]]
 name = "dioxus-logger"
-version = "0.7.6"
+version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0cbbee192b1b12fccb444a5b04d809710cfce4d27b792129fea6c845fae7f329"
+checksum = "a28ccdfe36d2cb830a2784e40f7e6f7199805a2c6da99bd65b1ca308f11aed28"
 dependencies = [
  "dioxus-cli-config",
  "tracing",
@@ -2057,9 +2057,9 @@ dependencies = [
 
 [[package]]
 name = "dioxus-router"
-version = "0.7.6"
+version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecdb19d7a1489ba252be9b3a07f9db92814020eb4ba8c1306f04242a44d17e66"
+checksum = "38e47f62d680429badfcb99bf5dec17ee92b0cb9623f264e36bc003a1359bfdc"
 dependencies = [
  "dioxus-cli-config",
  "dioxus-core",
@@ -2077,9 +2077,9 @@ dependencies = [
 
 [[package]]
 name = "dioxus-router-macro"
-version = "0.7.6"
+version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b525ab775585f1dc4850178de9d0cb6bb37f7b9c1a1a0c121eab7449d7021480"
+checksum = "6f83fb667d27e256f8c9eca49963fbace66a8722cb64ee15a10ffc97d092357e"
 dependencies = [
  "base16",
  "digest 0.10.7",
@@ -2092,9 +2092,9 @@ dependencies = [
 
 [[package]]
 name = "dioxus-rsx"
-version = "0.7.6"
+version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37fb07e40e9734946511659668ea3675ed214b60889e7aa7f0a5a85271518475"
+checksum = "2106afda239a4c7c22ffa1ca19117011225fc1c735c139c0a5b765996aa8bb1d"
 dependencies = [
  "proc-macro2",
  "proc-macro2-diagnostics",
@@ -2105,9 +2105,9 @@ dependencies = [
 
 [[package]]
 name = "dioxus-signals"
-version = "0.7.6"
+version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5393fd579f42c6547bf47ec0a2dedf2a366cd541d31deedc1059a096e6c35798"
+checksum = "3705754f5e043deec9fc7af0d159f18e5b21c02c47d255c7e477f31368f0b6d2"
 dependencies = [
  "dioxus-core",
  "futures-channel",
@@ -2121,9 +2121,9 @@ dependencies = [
 
 [[package]]
 name = "dioxus-stores"
-version = "0.7.6"
+version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1c59f52e8194439604dd35f8c540456c22b4a4b076930e424d0289f98ea3cb4"
+checksum = "64bec7b21c86b1360ec965a07a53a2c96b7caee3465049e1c299a45024e87614"
 dependencies = [
  "dioxus-core",
  "dioxus-signals",
@@ -2133,9 +2133,9 @@ dependencies = [
 
 [[package]]
 name = "dioxus-stores-macro"
-version = "0.7.6"
+version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "737600865572cecf60ff934f88252bd4144f4ca189e0e570b7a780e8f0e01a1f"
+checksum = "40a5875e9f890f27b1cc3e5b56c1e23601211470315a1fb8627c4ca4f3b2be9a"
 dependencies = [
  "convert_case 0.8.0",
  "proc-macro2",
@@ -2145,9 +2145,9 @@ dependencies = [
 
 [[package]]
 name = "dioxus-web"
-version = "0.7.6"
+version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "176eb0a5ee8251203a816b413a64fdc014b43e53d4245f769b1b0c2035b88ac3"
+checksum = "bc0a0be76b404e8242a597db0fb239d05f8dee4e7856bc1fc7144f7e244822fd"
 dependencies = [
  "dioxus-cli-config",
  "dioxus-core",
@@ -2913,9 +2913,9 @@ dependencies = [
 
 [[package]]
 name = "generational-box"
-version = "0.7.6"
+version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c68d74be1fbe3bba37604bdfd61403f26af9f6324cf325053abd89d60c22e799"
+checksum = "8cd0d825b8d339701ad330dbcd6399519ced4d143484954daf6e3185dace4f77"
 dependencies = [
  "parking_lot",
  "tracing",
@@ -4113,9 +4113,9 @@ dependencies = [
 
 [[package]]
 name = "lazy-js-bundle"
-version = "0.7.6"
+version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebbde2c5796719fbd82d6b8ec0be3dacf1f70c2876dee0f2c001632794d6641f"
+checksum = "ccafada6c9541db44db758619236f2748f6e1bdaa84d04ded858567cd1e89321"
 
 [[package]]
 name = "lazy_static"
@@ -4328,9 +4328,9 @@ dependencies = [
 
 [[package]]
 name = "manganis"
-version = "0.7.6"
+version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e06225f29a781d86afdfafa562de09621f2ace377136ae2ae9ca9e72a29b920"
+checksum = "8bfcf56309de35b48b8780ea097ace5c3b773a617b52edc49dfc9a63a7d9dc43"
 dependencies = [
  "const-serialize 0.7.2",
  "const-serialize 0.8.0-alpha.0",
@@ -4344,9 +4344,9 @@ dependencies = [
 
 [[package]]
 name = "manganis-core"
-version = "0.7.6"
+version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "774ddc382b4fb30f3fdcf2418131cbac5e6111f00e6c7ddf9e598ef3b2b4cd91"
+checksum = "a24d6be68f594495aea60850a284029d585d7b7839b26096c1b6d758f8518648"
 dependencies = [
  "const-serialize 0.7.2",
  "const-serialize 0.8.0-alpha.0",
@@ -4358,9 +4358,9 @@ dependencies = [
 
 [[package]]
 name = "manganis-macro"
-version = "0.7.6"
+version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "731c83c89d831f341fb46eba0aefdfb3433f77a3f78a8b08d9d88746613a8f8b"
+checksum = "5e782a10318d707c0833e31876ded8acf91287eee0010af8392559af614c7226"
 dependencies = [
  "dunce",
  "macro-string",
@@ -5504,7 +5504,7 @@ dependencies = [
  "futures-util",
  "hex",
  "regex-lite",
- "reqwest 0.13.2",
+ "reqwest 0.13.3",
  "reqwest-middleware",
  "reqwest-retry",
  "reqwest-tracing",
@@ -6268,9 +6268,9 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
-version = "0.13.2"
+version = "0.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab3f43e3283ab1488b624b44b0e988d0acea0b3214e694730a055cb6b2efa801"
+checksum = "62e0021ea2c22aed41653bc7e1419abb2c97e038ff2c33d0e1309e49a97deec0"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -6322,7 +6322,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "http",
- "reqwest 0.13.2",
+ "reqwest 0.13.3",
  "serde",
  "thiserror 2.0.18",
  "tower-service",
@@ -6340,7 +6340,7 @@ dependencies = [
  "getrandom 0.2.17",
  "http",
  "hyper",
- "reqwest 0.13.2",
+ "reqwest 0.13.3",
  "reqwest-middleware",
  "retry-policies",
  "thiserror 2.0.18",
@@ -6360,7 +6360,7 @@ dependencies = [
  "getrandom 0.2.17",
  "http",
  "matchit",
- "reqwest 0.13.2",
+ "reqwest 0.13.3",
  "reqwest-middleware",
  "tracing",
 ]
@@ -7602,9 +7602,9 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "subsecond"
-version = "0.7.6"
+version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "feae81a4a7ca6d0bcf70c385a43b7dbacbff527f0805cb0a4043ce2c2c559a2c"
+checksum = "9cc79674bd55726e6b123204403389400229a95fe4a3b2c5453dada70b06ca95"
 dependencies = [
  "js-sys",
  "libc",
@@ -7621,9 +7621,9 @@ dependencies = [
 
 [[package]]
 name = "subsecond-types"
-version = "0.7.6"
+version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85256ee192cbdf00473e48e6133863b125dd4f772fddfbc97287ec7a61458c25"
+checksum = "e9798bfed58797aed51c672aa99810aac30a50d3120ecfdcf28c13784e9a8f1c"
 dependencies = [
  "serde",
 ]

--- a/cli/src/commands/deck.rs
+++ b/cli/src/commands/deck.rs
@@ -1,0 +1,322 @@
+//! Pretty-print Arena decklists for the CLI.
+//!
+//! **`deck show` input precedence** (first match wins):
+//! 1. `--match-id` — load rows from Postgres `deck` for that match  
+//! 2. `--clipboard` — JSON text (macOS `pbpaste`)  
+//! 3. `[FILE]` — file contents, or `-` to read stdin once  
+//! 4. `--main` / `--side` — literal JSON arrays of Arena IDs  
+//! 5. piped stdin — when stdin is not a TTY (no `[FILE]` and no `--main`)
+
+use std::{
+    io::{self, IsTerminal, Read},
+    path::Path,
+};
+
+use arenabuddy_core::{cards::CardsDatabase, display::deck::DeckDisplayRecord, models::Deck};
+use arenabuddy_data::{ArenabuddyRepository, MatchDB, MetagameRepository};
+use serde_json::{Map, Value};
+
+use crate::{Error, Result};
+
+// --- CLI wiring (passed from `lib.rs`) ---------------------------------------
+
+/// Options collected from `arenabuddyctl deck show …`.
+pub(crate) struct DeckShowOpts<'a> {
+    pub cards_db: &'a Path,
+    pub db_url: Option<&'a str>,
+    pub match_id: Option<&'a str>,
+    pub game: Option<i32>,
+    pub input: Option<&'a Path>,
+    pub clipboard: bool,
+    pub main: Option<&'a str>,
+    pub side: Option<&'a str>,
+}
+
+/// What to render after precedence rules ([`determine_input`]) resolve.
+enum DeckShowInput<'a> {
+    /// Postgres `deck` table for controller, optional `deck.game_number` filter.
+    FromDatabase { match_id: &'a str, game: Option<i32> },
+    /// Raw JSON body: either `[id,…]` or `{"deck_cards":[…],"sideboard_cards":[…]}`.
+    RawJsonBody(String),
+    /// `--main` / `--side` strings (already JSON arrays of `i32`).
+    RawJsonCliArgs { main: &'a str, side: Option<&'a str> },
+}
+
+// --- Public entry ------------------------------------------------------------
+
+pub async fn show(opts: DeckShowOpts<'_>) -> Result<()> {
+    let catalog = CardsDatabase::new(opts.cards_db)?;
+
+    match determine_input(&opts)? {
+        DeckShowInput::FromDatabase { match_id, game } => {
+            let Some(db_url) = opts.db_url else {
+                return Err(Error::Invalid(
+                    "--match-id requires a database URL (`--db` or ARENABUDDY_DATABASE_URL).".into(),
+                ));
+            };
+            print_match_decks_from_db(&catalog, db_url, match_id, game).await?;
+        }
+        DeckShowInput::RawJsonBody(json) => {
+            let (main_ids, sideboard_ids) = parse_deck_arrays_json(&json)?;
+            let deck = Deck::new("Imported deck".to_string(), 0, main_ids, sideboard_ids);
+            print_single_deck(&catalog, &deck, "Imported deck (JSON)");
+        }
+        DeckShowInput::RawJsonCliArgs { main, side } => {
+            let main_ids = serde_json::from_str::<Vec<i32>>(main).map_err(crate::ParseError::Json)?;
+            let sideboard_ids = match side.map(str::trim) {
+                None | Some("") => Vec::new(),
+                Some(slice) => serde_json::from_str::<Vec<i32>>(slice).map_err(crate::ParseError::Json)?,
+            };
+            let deck = Deck::new("Imported deck".to_string(), 0, main_ids, sideboard_ids);
+            print_single_deck(&catalog, &deck, "Imported deck (--main / --side)");
+        }
+    }
+
+    Ok(())
+}
+
+// --- Resolve which input shape we have ---------------------------------------
+
+fn determine_input<'a>(opts: &'a DeckShowOpts<'a>) -> Result<DeckShowInput<'a>> {
+    use DeckShowInput as In;
+
+    if let Some(match_id) = opts.match_id {
+        return Ok(In::FromDatabase {
+            match_id,
+            game: opts.game,
+        });
+    }
+
+    if opts.clipboard {
+        return Ok(In::RawJsonBody(read_clipboard_text()?));
+    }
+
+    if let Some(path) = opts.input {
+        return Ok(In::RawJsonBody(read_file_or_stdin(path)?));
+    }
+
+    if let Some(main) = opts.main {
+        return Ok(In::RawJsonCliArgs { main, side: opts.side });
+    }
+
+    if io::stdin().is_terminal() {
+        return Err(Error::Invalid(
+            "Provide a deck: `--match-id`, `--clipboard`, a FILE (`-` for stdin), `--main`, or pipe JSON stdin.".into(),
+        ));
+    }
+
+    let mut piped = String::new();
+    io::stdin().read_to_string(&mut piped)?;
+    Ok(In::RawJsonBody(piped))
+}
+
+// --- Parsing: Postgres column / GRE JSON blobs ------------------------------
+
+/// Parses JSON like the `deck_cards` / `sideboard_cards` DB columns:
+/// - Bare array `[72447, 91717, …]` ⇒ mainboard only  
+/// - Object with `deck_cards` and optionally `sideboard_cards` (also accepts `main` / `mainboard`, `side` / `sideboard`)
+pub(crate) fn parse_deck_arrays_json(raw: &str) -> Result<(Vec<i32>, Vec<i32>)> {
+    let trimmed = raw.trim();
+    if trimmed.is_empty() {
+        return Err(Error::Invalid("deck JSON was empty".into()));
+    }
+
+    let root: Value = serde_json::from_str(trimmed).map_err(crate::ParseError::Json)?;
+
+    match root {
+        Value::Array(entries) => {
+            let mainboard = json_values_as_arena_ids(entries)?;
+            Ok((mainboard, Vec::new()))
+        }
+        Value::Object(fields) => {
+            let mainboard_value = alternate_field(&fields, &["deck_cards", "main", "mainboard"]);
+            let sideboard_value = alternate_field(&fields, &["sideboard_cards", "side", "sideboard"]);
+            Ok((
+                parse_optional_id_array_field(mainboard_value, "deck_cards (mainboard)")?,
+                parse_optional_id_array_field(sideboard_value, "sideboard_cards")?,
+            ))
+        }
+        _ => Err(Error::Invalid(
+            "Deck JSON must be an integer ID array or an object with deck_cards / sideboard_cards arrays.".into(),
+        )),
+    }
+}
+
+fn alternate_field<'a>(fields: &'a Map<String, Value>, keys: &[&str]) -> Option<&'a Value> {
+    keys.iter().find_map(|k| fields.get(*k))
+}
+
+fn parse_optional_id_array_field(entry: Option<&Value>, label: &'static str) -> Result<Vec<i32>> {
+    match entry {
+        None => Ok(Vec::new()),
+        Some(Value::Array(entries)) => json_values_as_arena_ids(entries.clone()),
+        Some(_) => Err(Error::Invalid(format!(
+            "`{label}` must be a JSON array of Arena card IDs."
+        ))),
+    }
+}
+
+fn json_values_as_arena_ids(entries: Vec<Value>) -> Result<Vec<i32>> {
+    let mut ids = Vec::with_capacity(entries.len());
+    for value in entries {
+        let n = value
+            .as_i64()
+            .ok_or_else(|| Error::Invalid("Deck arrays must contain integer Arena card IDs.".into()))?;
+        let id = i32::try_from(n).map_err(|_| Error::Invalid(format!("Arena ID out of range: {n}")))?;
+        ids.push(id);
+    }
+    Ok(ids)
+}
+
+// --- IO helpers --------------------------------------------------------------
+
+fn read_file_or_stdin(path: &Path) -> Result<String> {
+    if path.as_os_str() == "-" {
+        let mut buf = String::new();
+        io::stdin().read_to_string(&mut buf)?;
+        Ok(buf)
+    } else {
+        std::fs::read_to_string(path).map_err(Error::Io)
+    }
+}
+
+#[cfg(target_os = "macos")]
+fn read_clipboard_text() -> Result<String> {
+    use std::process::Command;
+    let output = Command::new("pbpaste").output().map_err(Error::Io)?;
+    if !output.status.success() {
+        return Err(Error::Invalid(
+            "`pbpaste` failed. Copy deck JSON again, or save it to a file and pass that path.".into(),
+        ));
+    }
+    Ok(String::from_utf8_lossy(&output.stdout).into_owned())
+}
+
+#[cfg(not(target_os = "macos"))]
+fn read_clipboard_text() -> Result<String> {
+    Err(Error::Invalid(
+        "`--clipboard` only works on macOS (uses `pbpaste`). Pipe JSON or pass a FILE instead.".into(),
+    ))
+}
+
+// --- Render (`DeckDisplayRecord` + pretty_print) ----------------------------
+
+async fn print_match_decks_from_db(
+    catalog: &CardsDatabase,
+    db_url: &str,
+    match_id: &str,
+    filter_game_number: Option<i32>,
+) -> Result<()> {
+    let db = MatchDB::new(Some(db_url), catalog.clone()).await?;
+    db.init().await?;
+
+    let mut decks = db.list_decklists(match_id).await?;
+    if decks.is_empty() {
+        return Err(Error::Invalid(format!(
+            "No deck rows for match `{match_id}` (controller rows in Postgres `deck` table)."
+        )));
+    }
+    decks.sort_by_key(Deck::game_number);
+
+    let archetypes = db.get_match_archetypes(match_id).await;
+    let (controller_label, opponent_label) = archetypes.unwrap_or((None, None));
+
+    match filter_game_number {
+        Some(game_number) => {
+            let chosen = decks
+                .into_iter()
+                .find(|d| d.game_number() == game_number)
+                .ok_or_else(|| Error::Invalid(format!("No deck row with game_number={game_number} for this match.")))?;
+            let headline = deck_headline(match_id, game_number, chosen.name());
+            print_one_game_with_archetypes(
+                catalog,
+                &chosen,
+                &headline,
+                controller_label.as_deref(),
+                opponent_label.as_deref(),
+            );
+        }
+        None => {
+            for deck in decks {
+                let game_number = deck.game_number();
+                let headline = deck_headline(match_id, game_number, deck.name());
+                print_one_game_with_archetypes(
+                    catalog,
+                    &deck,
+                    &headline,
+                    controller_label.as_deref(),
+                    opponent_label.as_deref(),
+                );
+                println!();
+            }
+        }
+    }
+    Ok(())
+}
+
+fn deck_headline(match_id: &str, game_number: i32, deck_name_from_row: &str) -> String {
+    format!("Match `{match_id}` · game {game_number} · controller ({deck_name_from_row})")
+}
+
+fn print_one_game_with_archetypes(
+    catalog: &CardsDatabase,
+    deck: &Deck,
+    headline: &str,
+    controller_archetype: Option<&str>,
+    opponent_archetype: Option<&str>,
+) {
+    let mut record = DeckDisplayRecord::from_decklist(deck, catalog);
+
+    record.archetype = match controller_archetype {
+        Some(label) => label.to_owned(),
+        None => "Unknown".to_owned(),
+    };
+
+    print_deck_header(headline, &record, opponent_archetype);
+
+    let body = record.pretty_print();
+    print!("{body}");
+}
+
+fn print_single_deck(catalog: &CardsDatabase, deck: &Deck, heading: &str) {
+    let record = DeckDisplayRecord::from_decklist(deck, catalog);
+    print_deck_header(heading, &record, None);
+    let body = record.pretty_print();
+    print!("{body}");
+}
+
+fn print_deck_header(title_line: &str, record: &DeckDisplayRecord, opponent_archetype: Option<&str>) {
+    println!("{title_line}");
+    let (main_total, side_total) = record.totals();
+    println!("Cards: {main_total} main · {side_total} sideboard");
+
+    let controller = record.archetype.as_str();
+    if controller != "Unknown" && !controller.is_empty() {
+        println!("Classifier archetype (controller): {controller}");
+    }
+
+    if let Some(opp) = opponent_archetype {
+        println!("Classifier archetype (opponent): {opp}");
+    }
+    println!();
+}
+
+#[cfg(test)]
+mod tests {
+    use super::parse_deck_arrays_json;
+
+    #[test]
+    fn parse_plain_array_is_main_only() {
+        let (main, side) = parse_deck_arrays_json("[1,2,2]").expect("parse");
+        assert_eq!(main, vec![1, 2, 2]);
+        assert!(side.is_empty());
+    }
+
+    #[test]
+    fn parse_gre_style_object() {
+        let raw = r#"{"deck_cards":[72447,91717],"sideboard_cards":[1]}"#;
+        let (main, side) = parse_deck_arrays_json(raw).expect("parse");
+        assert_eq!(main, vec![72447, 91717]);
+        assert_eq!(side, vec![1]);
+    }
+}

--- a/cli/src/commands/definitions.rs
+++ b/cli/src/commands/definitions.rs
@@ -79,6 +79,51 @@ pub enum Commands {
         #[arg(long, help = "Filter to a specific game number")]
         game: Option<i32>,
     },
+
+    /// Pretty-print decks from Postgres or JSON Arena card ID lists
+    Deck {
+        #[command(subcommand)]
+        command: DeckCommands,
+    },
+}
+
+#[derive(Debug, Subcommand)]
+pub enum DeckCommands {
+    /// Print a deck using `DeckDisplayRecord` names (Protobuf card DB)
+    Show {
+        #[arg(
+            short = 'c',
+            long,
+            default_value = "data/cards-full.pb",
+            help = "Protobuf card database (same as parse --cards-db)"
+        )]
+        cards_db: PathBuf,
+
+        #[arg(
+            long,
+            env = "ARENABUDDY_DATABASE_URL",
+            help = "PostgreSQL URL (required with --match-id)"
+        )]
+        db: Option<String>,
+
+        #[arg(long, conflicts_with_all = ["clipboard", "main", "input"], help = "Match UUID (controller rows in `deck` table)")]
+        match_id: Option<String>,
+
+        #[arg(long, help = "Game number (`deck.game_number`); omit to print every game")]
+        game: Option<i32>,
+
+        #[arg(long, conflicts_with_all = ["match_id", "main", "input"], help = "Deck JSON from macOS clipboard (`pbpaste`)")]
+        clipboard: bool,
+
+        #[arg(value_name = "FILE", conflicts_with_all = ["match_id", "clipboard", "main"], help = "Deck JSON file, or `-` for stdin")]
+        input: Option<PathBuf>,
+
+        #[arg(long, conflicts_with_all = ["match_id", "clipboard", "input"], help = "Mainboard as JSON integer array")]
+        main: Option<String>,
+
+        #[arg(long, requires = "main", help = "Sideboard as JSON integer array")]
+        side: Option<String>,
+    },
 }
 
 #[derive(Debug, Subcommand)]

--- a/cli/src/commands/mod.rs
+++ b/cli/src/commands/mod.rs
@@ -1,3 +1,4 @@
+pub mod deck;
 pub mod definitions;
 pub mod event_log;
 pub mod metagame;
@@ -7,4 +8,4 @@ pub mod scrape;
 pub mod scrape_mtga;
 pub mod scryfall;
 
-pub use definitions::Commands;
+pub use definitions::{Commands, DeckCommands};

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -4,7 +4,7 @@ use clap::Parser;
 mod commands;
 mod errors;
 
-use commands::Commands;
+use commands::{Commands, DeckCommands};
 pub use errors::{Error, ParseError, Result};
 
 #[derive(Debug, Parser)]
@@ -76,6 +76,31 @@ pub async fn run() -> Result<()> {
         } => {
             commands::event_log::execute(player_log, cards_db.as_ref(), output.as_ref(), *game).await?;
         }
+
+        Commands::Deck { command } => match command {
+            DeckCommands::Show {
+                cards_db,
+                db,
+                match_id,
+                game,
+                clipboard,
+                input,
+                main,
+                side,
+            } => {
+                commands::deck::show(commands::deck::DeckShowOpts {
+                    cards_db: cards_db.as_path(),
+                    db_url: db.as_deref(),
+                    match_id: match_id.as_deref(),
+                    game: *game,
+                    input: input.as_ref().map(std::path::PathBuf::as_path),
+                    clipboard: *clipboard,
+                    main: main.as_deref(),
+                    side: side.as_deref(),
+                })
+                .await?;
+            }
+        },
     }
 
     Ok(())

--- a/core/src/events/gre.rs
+++ b/core/src/events/gre.rs
@@ -441,6 +441,8 @@ pub enum GameObjectType {
     RoomRight,
     #[serde(rename = "GameObjectType_SplitLeft")]
     SplitLeft,
+    #[serde(rename = "GameObjectType_SplitRight")]
+    SplitRight,
     #[serde(rename = "GameObjectType_Omen")]
     Omen,
     #[serde(rename = "GameObjectType_Emblem")]


### PR DESCRIPTION
## Add `deck show` CLI command and dependency updates

Introduces a new `arenabuddyctl deck show` subcommand that pretty-prints Arena decklists using `DeckDisplayRecord`. The command resolves its input through a precedence chain:

1. `--match-id` — loads controller deck rows from the Postgres `deck` table, with an optional `--game` filter
2. `--clipboard` — reads JSON from the macOS clipboard via `pbpaste`
3. `[FILE]` — reads a deck JSON file, or `-` to consume stdin once
4. `--main` / `--side` — accepts literal JSON integer arrays directly on the command line
5. Piped stdin — used as a fallback when stdin is not a TTY

The JSON parser handles both bare integer arrays (mainboard only) and objects with `deck_cards`/`sideboard_cards` keys (also accepting `main`/`mainboard` and `side`/`sideboard` aliases). When loading from the database, decks are sorted by game number and annotated with controller and opponent archetype labels where available.

Also bumps `reqwest` from 0.13.2 to 0.13.3 and `dioxus` (and all related crates) from 0.7.6 to 0.7.9, and adds a missing `GameObjectType_SplitRight` variant to the GRE event enum.