### PR TITLE
Add MTGA startup daemon

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -199,6 +199,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "arenabuddy_daemon"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "clap",
+ "ctrlc",
+ "sysinfo",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "arenabuddy_data"
 version = "0.1.0"
 dependencies = [
@@ -4679,6 +4691,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ntapi"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3b335231dfd352ffb0f8017f3b6027a4917f7df785ea2143d8af2adc66980ae"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "nu-ansi-term"
 version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4926,6 +4947,16 @@ dependencies = [
  "bitflags 2.11.1",
  "block2",
  "objc2",
+ "objc2-core-foundation",
+]
+
+[[package]]
+name = "objc2-io-kit"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33fafba39597d6dc1fb709123dfa8289d39406734be322956a69f0931c73bb15"
+dependencies = [
+ "libc",
  "objc2-core-foundation",
 ]
 
@@ -7495,6 +7526,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "sysinfo"
+version = "0.38.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92ab6a2f8bfe508deb3c6406578252e491d299cbbf3bc0529ecc3313aee4a52f"
+dependencies = [
+ "libc",
+ "memchr",
+ "ntapi",
+ "objc2-core-foundation",
+ "objc2-io-kit",
+ "windows 0.62.2",
+]
+
+[[package]]
 name = "system-configuration"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7563,7 +7608,7 @@ dependencies = [
  "tao-macros",
  "unicode-segmentation",
  "url",
- "windows",
+ "windows 0.61.3",
  "windows-core 0.61.2",
  "windows-version",
  "x11-dl",
@@ -8692,7 +8737,7 @@ checksum = "7130243a7a5b33c54a444e54842e6a9e133de08b5ad7b5861cd8ed9a6a5bc96a"
 dependencies = [
  "webview2-com-macros",
  "webview2-com-sys",
- "windows",
+ "windows 0.61.3",
  "windows-core 0.61.2",
  "windows-implement",
  "windows-interface",
@@ -8716,7 +8761,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "381336cfffd772377d291702245447a5251a2ffa5bad679c99e61bc48bacbf9c"
 dependencies = [
  "thiserror 2.0.18",
- "windows",
+ "windows 0.61.3",
  "windows-core 0.61.2",
 ]
 
@@ -8779,11 +8824,23 @@ version = "0.61.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9babd3a767a4c1aef6900409f85f5d53ce2544ccdfaa86dad48c91782c6d6893"
 dependencies = [
- "windows-collections",
+ "windows-collections 0.2.0",
  "windows-core 0.61.2",
- "windows-future",
+ "windows-future 0.2.1",
  "windows-link 0.1.3",
- "windows-numerics",
+ "windows-numerics 0.2.0",
+]
+
+[[package]]
+name = "windows"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "527fadee13e0c05939a6a05d5bd6eec6cd2e3dbd648b9f8e447c6518133d8580"
+dependencies = [
+ "windows-collections 0.3.2",
+ "windows-core 0.62.2",
+ "windows-future 0.3.2",
+ "windows-numerics 0.3.1",
 ]
 
 [[package]]
@@ -8793,6 +8850,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3beeceb5e5cfd9eb1d76b381630e82c4241ccd0d27f1a39ed41b2760b255c5e8"
 dependencies = [
  "windows-core 0.61.2",
+]
+
+[[package]]
+name = "windows-collections"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b2d95af1a8a14a3c7367e1ed4fc9c20e0a26e79551b1454d72583c97cc6610"
+dependencies = [
+ "windows-core 0.62.2",
 ]
 
 [[package]]
@@ -8829,7 +8895,18 @@ checksum = "fc6a41e98427b19fe4b73c550f060b59fa592d7d686537eebf9385621bfbad8e"
 dependencies = [
  "windows-core 0.61.2",
  "windows-link 0.1.3",
- "windows-threading",
+ "windows-threading 0.1.0",
+]
+
+[[package]]
+name = "windows-future"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1d6f90251fe18a279739e78025bd6ddc52a7e22f921070ccdc67dde84c605cb"
+dependencies = [
+ "windows-core 0.62.2",
+ "windows-link 0.2.1",
+ "windows-threading 0.2.1",
 ]
 
 [[package]]
@@ -8874,6 +8951,16 @@ checksum = "9150af68066c4c5c07ddc0ce30421554771e528bde427614c61038bc2c92c2b1"
 dependencies = [
  "windows-core 0.61.2",
  "windows-link 0.1.3",
+]
+
+[[package]]
+name = "windows-numerics"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e2e40844ac143cdb44aead537bbf727de9b044e107a0f1220392177d15b0f26"
+dependencies = [
+ "windows-core 0.62.2",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -9047,6 +9134,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b66463ad2e0ea3bbf808b7f1d371311c80e115c0b71d60efc142cafbcfb057a6"
 dependencies = [
  "windows-link 0.1.3",
+]
+
+[[package]]
+name = "windows-threading"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3949bd5b99cafdf1c7ca86b43ca564028dfe27d66958f2470940f73d86d75b37"
+dependencies = [
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -9402,7 +9498,7 @@ dependencies = [
  "webkit2gtk",
  "webkit2gtk-sys",
  "webview2-com",
- "windows",
+ "windows 0.61.3",
  "windows-core 0.61.2",
  "windows-version",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ members = [
     "server",
     "web",
     "metagame",
+    "daemon",
 ]
 resolver = "3"
 
@@ -71,6 +72,7 @@ sqlx = { version = "0.9.0", features = [
     "sqlx-toml",
     "rust_decimal",
 ] }
+sysinfo = "0.38.4"
 thiserror = "2.0.18"
 tokio = { version = "1.52.3", features = ["full", "tracing"] }
 tracing = "0.1.44"

--- a/README.md
+++ b/README.md
@@ -44,12 +44,28 @@ To get started with the ArenaBuddy development environment, follow these steps:
 
    You can get help on any command with `cargo run -p arenabuddy_cli -- --help` or `cargo run -p arenabuddy_cli -- <command> --help`.
 
-4. Project Structure:
+4. MTGA startup daemon:
+
+   `arenabuddy-daemon` is a small process watcher that starts ArenaBuddy when it sees Magic Arena running. It does not parse logs itself; it only launches the desktop app if an ArenaBuddy process is not already running.
+
+   ```bash
+   # Development example: build the app, then run one dry process scan
+   cargo build -p arenabuddy
+   cargo run -p arenabuddy_daemon -- --arenabuddy ./target/debug/arenabuddy --once --dry-run
+
+   # Run continuously and poll every 5 seconds
+   cargo run -p arenabuddy_daemon -- --arenabuddy ./target/debug/arenabuddy
+   ```
+
+   For installed builds, either place `arenabuddy-daemon` next to the ArenaBuddy executable or set `ARENABUDDY_APP_PATH` to the app binary path. The daemon can then be registered with the operating system's per-user startup facility, such as a macOS LaunchAgent, Windows Task Scheduler entry, or Linux user systemd unit.
+
+5. Project Structure:
 
    - `/core` - common modules
    - `/cli` - Consolidated command line tool for log parsing and card scraping
    - `/data` - data layer
    - `/arenabuddy` - Dioxus desktop app
+   - `/daemon` - process watcher that can start the desktop app with MTGA
    - `/server` - gRPC backend service
    - `/web` - Web splash page
    - `/metagame` - Metagame scraping and deck classification

--- a/daemon/Cargo.toml
+++ b/daemon/Cargo.toml
@@ -1,0 +1,26 @@
+[package]
+name = "arenabuddy_daemon"
+authors.workspace = true
+description = "Start ArenaBuddy when Magic Arena is running"
+categories.workspace = true
+version.workspace = true
+repository.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+keywords.workspace = true
+license.workspace = true
+
+[dependencies]
+anyhow = { workspace = true }
+clap = { workspace = true }
+ctrlc = { workspace = true }
+sysinfo = { workspace = true }
+tracing = { workspace = true }
+tracing-subscriber = { workspace = true, features = ["env-filter", "fmt"] }
+
+[lints]
+workspace = true
+
+[[bin]]
+name = "arenabuddy-daemon"
+path = "src/main.rs"

--- a/daemon/src/lib.rs
+++ b/daemon/src/lib.rs
@@ -1,0 +1,291 @@
+use std::{
+    path::{Path, PathBuf},
+    process::{Command, Stdio},
+    sync::{
+        Arc,
+        atomic::{AtomicBool, Ordering},
+    },
+    time::{Duration, Instant},
+};
+
+use anyhow::{Context, Result, anyhow};
+use sysinfo::{ProcessesToUpdate, System};
+use tracing::{debug, info};
+
+pub const ARENABUDDY_APP_PATH_ENV: &str = "ARENABUDDY_APP_PATH";
+
+#[derive(Debug, Clone)]
+pub struct DaemonConfig {
+    pub arenabuddy_path: PathBuf,
+    pub mtga_process_names: Vec<String>,
+    pub arenabuddy_process_names: Vec<String>,
+    pub poll_interval: Duration,
+    pub launch_cooldown: Duration,
+    pub run_once: bool,
+    pub dry_run: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ProcessInfo {
+    pub name: String,
+    pub executable_name: Option<String>,
+}
+
+pub fn default_mtga_process_names() -> Vec<String> {
+    vec!["MTGA.exe".to_owned(), "MTGA".to_owned()]
+}
+
+pub fn default_arenabuddy_process_names() -> Vec<String> {
+    vec![
+        "arenabuddy".to_owned(),
+        "Arenabuddy".to_owned(),
+        "arenabuddy.exe".to_owned(),
+        "Arenabuddy.exe".to_owned(),
+    ]
+}
+
+pub fn resolve_arenabuddy_path(configured_path: Option<&Path>) -> Result<PathBuf> {
+    if let Some(path) = configured_path {
+        return existing_path(path);
+    }
+
+    if let Some(path) = std::env::var_os(ARENABUDDY_APP_PATH_ENV) {
+        return existing_path(Path::new(&path));
+    }
+
+    let current_executable = std::env::current_exe().context("failed to resolve current daemon executable")?;
+    let executable_dir = current_executable
+        .parent()
+        .ok_or_else(|| anyhow!("daemon executable does not have a parent directory"))?;
+
+    sibling_arenabuddy_candidates(executable_dir)
+        .into_iter()
+        .find(|path| path.exists())
+        .ok_or_else(|| {
+            anyhow!(
+                "could not find ArenaBuddy next to the daemon; pass --arenabuddy <path> or set {ARENABUDDY_APP_PATH_ENV}"
+            )
+        })
+}
+
+pub fn sibling_arenabuddy_candidates(executable_dir: &Path) -> Vec<PathBuf> {
+    let mut candidates = Vec::new();
+
+    #[cfg(target_os = "macos")]
+    {
+        candidates.push(executable_dir.join("Arenabuddy.app"));
+    }
+
+    candidates.push(executable_dir.join(platform_executable_name("arenabuddy")));
+    candidates.push(executable_dir.join(platform_executable_name("Arenabuddy")));
+    candidates
+}
+
+pub fn process_name_matches(actual: &str, expected: &str) -> bool {
+    let actual = normalize_process_name(actual);
+    let expected = normalize_process_name(expected);
+    strip_exe_suffix(&actual) == strip_exe_suffix(&expected)
+}
+
+pub fn has_matching_process(processes: &[ProcessInfo], target_names: &[String]) -> bool {
+    processes.iter().any(|process| {
+        target_names.iter().any(|target| {
+            process_name_matches(&process.name, target)
+                || process
+                    .executable_name
+                    .as_deref()
+                    .is_some_and(|name| process_name_matches(name, target))
+        })
+    })
+}
+
+pub fn run(config: &DaemonConfig) -> Result<()> {
+    validate_config(config)?;
+
+    let keep_running = Arc::new(AtomicBool::new(true));
+    let signal_flag = Arc::clone(&keep_running);
+    ctrlc::set_handler(move || signal_flag.store(false, Ordering::SeqCst))?;
+
+    let mut system = System::new();
+    let mut last_launch = None;
+
+    info!(
+        "watching for MTGA processes {:?}; ArenaBuddy process names {:?}",
+        config.mtga_process_names, config.arenabuddy_process_names
+    );
+    info!("will launch ArenaBuddy from {}", config.arenabuddy_path.display());
+
+    while keep_running.load(Ordering::SeqCst) {
+        scan_once(config, &mut system, &mut last_launch)?;
+
+        if config.run_once {
+            break;
+        }
+
+        std::thread::sleep(config.poll_interval);
+    }
+
+    Ok(())
+}
+
+fn validate_config(config: &DaemonConfig) -> Result<()> {
+    if config.poll_interval.is_zero() {
+        return Err(anyhow!("poll interval must be greater than zero"));
+    }
+
+    if config.mtga_process_names.is_empty() {
+        return Err(anyhow!("at least one MTGA process name is required"));
+    }
+
+    if config.arenabuddy_process_names.is_empty() {
+        return Err(anyhow!("at least one ArenaBuddy process name is required"));
+    }
+
+    Ok(())
+}
+
+fn scan_once(config: &DaemonConfig, system: &mut System, last_launch: &mut Option<Instant>) -> Result<()> {
+    system.refresh_processes(ProcessesToUpdate::All, true);
+    let processes = collect_processes(system);
+    let mtga_running = has_matching_process(&processes, &config.mtga_process_names);
+    let arenabuddy_running = has_matching_process(&processes, &config.arenabuddy_process_names);
+
+    debug!(
+        "scan complete: mtga_running={mtga_running}, arenabuddy_running={arenabuddy_running}, process_count={}",
+        processes.len()
+    );
+
+    if !mtga_running {
+        return Ok(());
+    }
+
+    if arenabuddy_running {
+        debug!("MTGA is running and ArenaBuddy is already running");
+        return Ok(());
+    }
+
+    if last_launch.is_some_and(|launched_at| launched_at.elapsed() < config.launch_cooldown) {
+        debug!("MTGA is running, but ArenaBuddy launch is cooling down");
+        return Ok(());
+    }
+
+    launch_arenabuddy(config)?;
+    *last_launch = Some(Instant::now());
+    Ok(())
+}
+
+fn collect_processes(system: &System) -> Vec<ProcessInfo> {
+    system
+        .processes()
+        .values()
+        .map(|process| ProcessInfo {
+            name: process.name().to_string_lossy().into_owned(),
+            executable_name: process
+                .exe()
+                .and_then(Path::file_name)
+                .map(|name| name.to_string_lossy().into_owned()),
+        })
+        .collect()
+}
+
+fn launch_arenabuddy(config: &DaemonConfig) -> Result<()> {
+    if config.dry_run {
+        info!("dry run: would launch {}", config.arenabuddy_path.display());
+        return Ok(());
+    }
+
+    info!("MTGA is running; launching {}", config.arenabuddy_path.display());
+    let mut command = arenabuddy_command(&config.arenabuddy_path);
+    command
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()
+        .with_context(|| format!("failed to launch {}", config.arenabuddy_path.display()))?;
+
+    Ok(())
+}
+
+#[cfg(target_os = "macos")]
+fn arenabuddy_command(path: &Path) -> Command {
+    if is_app_bundle(path) {
+        let mut command = Command::new("open");
+        command.arg(path);
+        return command;
+    }
+
+    Command::new(path)
+}
+
+#[cfg(not(target_os = "macos"))]
+fn arenabuddy_command(path: &Path) -> Command {
+    Command::new(path)
+}
+
+#[cfg(target_os = "macos")]
+fn is_app_bundle(path: &Path) -> bool {
+    path.extension()
+        .and_then(std::ffi::OsStr::to_str)
+        .is_some_and(|extension| extension.eq_ignore_ascii_case("app"))
+}
+
+fn existing_path(path: &Path) -> Result<PathBuf> {
+    if path.exists() {
+        Ok(path.to_path_buf())
+    } else {
+        Err(anyhow!("ArenaBuddy executable does not exist: {}", path.display()))
+    }
+}
+
+fn normalize_process_name(name: &str) -> String {
+    name.trim().trim_matches('"').to_ascii_lowercase()
+}
+
+fn strip_exe_suffix(name: &str) -> &str {
+    name.strip_suffix(".exe").unwrap_or(name)
+}
+
+fn platform_executable_name(name: &str) -> String {
+    if cfg!(target_os = "windows") {
+        format!("{name}.exe")
+    } else {
+        name.to_owned()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::Path;
+
+    use super::{
+        ProcessInfo, has_matching_process, platform_executable_name, process_name_matches,
+        sibling_arenabuddy_candidates,
+    };
+
+    #[test]
+    fn process_matching_ignores_case_and_exe_suffix() {
+        assert!(process_name_matches("MTGA.exe", "mtga"));
+        assert!(process_name_matches("mtga", "MTGA.EXE"));
+        assert!(process_name_matches("Arenabuddy", "arenabuddy.exe"));
+        assert!(!process_name_matches("MTGAInstaller.exe", "MTGA.exe"));
+    }
+
+    #[test]
+    fn process_matching_checks_executable_name() {
+        let processes = vec![ProcessInfo {
+            name: "wine64-preloader".to_owned(),
+            executable_name: Some("MTGA.exe".to_owned()),
+        }];
+        let targets = vec!["mtga".to_owned()];
+
+        assert!(has_matching_process(&processes, &targets));
+    }
+
+    #[test]
+    fn sibling_candidates_include_platform_binary_name() {
+        let candidates = sibling_arenabuddy_candidates(Path::new("/tmp"));
+        let expected = Path::new("/tmp").join(platform_executable_name("arenabuddy"));
+
+        assert!(candidates.contains(&expected));
+    }
+}

--- a/daemon/src/lib.rs
+++ b/daemon/src/lib.rs
@@ -69,16 +69,12 @@ pub fn resolve_arenabuddy_path(configured_path: Option<&Path>) -> Result<PathBuf
 }
 
 pub fn sibling_arenabuddy_candidates(executable_dir: &Path) -> Vec<PathBuf> {
-    let mut candidates = Vec::new();
-
-    #[cfg(target_os = "macos")]
-    {
-        candidates.push(executable_dir.join("Arenabuddy.app"));
-    }
-
-    candidates.push(executable_dir.join(platform_executable_name("arenabuddy")));
-    candidates.push(executable_dir.join(platform_executable_name("Arenabuddy")));
-    candidates
+    vec![
+        #[cfg(target_os = "macos")]
+        executable_dir.join("Arenabuddy.app"),
+        executable_dir.join(platform_executable_name("arenabuddy")),
+        executable_dir.join(platform_executable_name("Arenabuddy")),
+    ]
 }
 
 pub fn process_name_matches(actual: &str, expected: &str) -> bool {

--- a/daemon/src/main.rs
+++ b/daemon/src/main.rs
@@ -1,0 +1,77 @@
+use std::{path::PathBuf, time::Duration};
+
+use anyhow::Result;
+use arenabuddy_daemon::{
+    DaemonConfig, default_arenabuddy_process_names, default_mtga_process_names, resolve_arenabuddy_path, run,
+};
+use clap::Parser;
+
+#[derive(Debug, Parser)]
+#[command(
+    name = "arenabuddy-daemon",
+    about = "Watch for Magic Arena and start ArenaBuddy when it is running"
+)]
+struct Cli {
+    #[arg(
+        long,
+        value_name = "PATH",
+        help = "ArenaBuddy executable or macOS .app bundle path. Defaults to ARENABUDDY_APP_PATH, then a sibling binary"
+    )]
+    arenabuddy: Option<PathBuf>,
+
+    #[arg(
+        long = "mtga-process",
+        value_name = "NAME",
+        help = "Magic Arena process name to watch for. Can be provided multiple times"
+    )]
+    mtga_process_names: Vec<String>,
+
+    #[arg(
+        long = "arenabuddy-process",
+        value_name = "NAME",
+        help = "ArenaBuddy process name used to avoid duplicate launches. Can be provided multiple times"
+    )]
+    arenabuddy_process_names: Vec<String>,
+
+    #[arg(long, default_value_t = 5, help = "Seconds between process scans")]
+    poll_interval_seconds: u64,
+
+    #[arg(
+        long,
+        default_value_t = 30,
+        help = "Seconds to wait after a launch attempt before trying again"
+    )]
+    launch_cooldown_seconds: u64,
+
+    #[arg(long, help = "Run one process scan and exit")]
+    once: bool,
+
+    #[arg(long, help = "Log launch decisions without starting ArenaBuddy")]
+    dry_run: bool,
+}
+
+fn main() -> Result<()> {
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::try_from_default_env()
+                .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("info")),
+        )
+        .init();
+
+    let cli = Cli::parse();
+    let config = DaemonConfig {
+        arenabuddy_path: resolve_arenabuddy_path(cli.arenabuddy.as_deref())?,
+        mtga_process_names: defaults_if_empty(cli.mtga_process_names, default_mtga_process_names()),
+        arenabuddy_process_names: defaults_if_empty(cli.arenabuddy_process_names, default_arenabuddy_process_names()),
+        poll_interval: Duration::from_secs(cli.poll_interval_seconds),
+        launch_cooldown: Duration::from_secs(cli.launch_cooldown_seconds),
+        run_once: cli.once,
+        dry_run: cli.dry_run,
+    };
+
+    run(&config)
+}
+
+fn defaults_if_empty(values: Vec<String>, defaults: Vec<String>) -> Vec<String> {
+    if values.is_empty() { defaults } else { values }
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Add an `arenabuddy-daemon` workspace binary that watches for Magic Arena process names and launches ArenaBuddy when needed
- Avoid duplicate launches by checking existing ArenaBuddy process names and applying a launch cooldown
- Support explicit `--arenabuddy` paths, `ARENABUDDY_APP_PATH`, sibling executable discovery, dry-run, and one-shot scans
- Document development usage and OS startup integration options in the README

## Testing
- `SQLX_OFFLINE=true cargo +nightly check -p arenabuddy_daemon --all-targets`
- `SQLX_OFFLINE=true cargo +nightly test -p arenabuddy_daemon`
- `SQLX_OFFLINE=true cargo +nightly clippy -p arenabuddy_daemon --all-targets --all-features -- -D warnings`
- `cargo +nightly fmt --all -- --check`
- `SQLX_OFFLINE=true cargo +nightly run -p arenabuddy_daemon -- --arenabuddy /bin/true --once --dry-run`
- `SQLX_OFFLINE=true cargo +nightly check --profile ci --workspace --all-targets --all-features`
- `SQLX_OFFLINE=true cargo +nightly clippy --profile ci --all --all-targets --all-features --examples --tests`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c5725dcd-32e0-4c3f-9664-a8a459e2d1b9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c5725dcd-32e0-4c3f-9664-a8a459e2d1b9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

