### PR TITLE
test: add unit tests for event log, match summary, stats, mulligan, draft, and processor modules

### DIFF
--- a/core/src/display/event_log.rs
+++ b/core/src/display/event_log.rs
@@ -345,3 +345,404 @@ fn zone_transfer_display(card: &CardRef, from_zone: &str, to_zone: &str, categor
         },
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::models::ArenaId;
+
+    fn named_card(name: &str) -> CardRef {
+        CardRef {
+            instance_id: 1,
+            arena_id: Some(ArenaId::new(100)),
+            name: Some(name.to_string()),
+        }
+    }
+
+    fn unnamed_card_with_arena_id(arena_id: i32) -> CardRef {
+        CardRef {
+            instance_id: 42,
+            arena_id: Some(ArenaId::new(arena_id)),
+            name: None,
+        }
+    }
+
+    fn unnamed_card_instance_only(instance_id: i32) -> CardRef {
+        CardRef {
+            instance_id,
+            arena_id: None,
+            name: None,
+        }
+    }
+
+    fn named_player(name: &str, seat: i32) -> PlayerRef {
+        PlayerRef {
+            seat_id: seat,
+            name: Some(name.to_string()),
+        }
+    }
+
+    fn anonymous_player(seat: i32) -> PlayerRef {
+        PlayerRef {
+            seat_id: seat,
+            name: None,
+        }
+    }
+
+    // -- card_display ---------------------------------------------------------
+
+    #[test]
+    fn card_display_with_name() {
+        assert_eq!(card_display(&named_card("Lightning Bolt")), "Lightning Bolt");
+    }
+
+    #[test]
+    fn card_display_fallback_to_arena_id() {
+        assert_eq!(card_display(&unnamed_card_with_arena_id(12345)), "Card #12345");
+    }
+
+    #[test]
+    fn card_display_fallback_to_instance_id() {
+        assert_eq!(card_display(&unnamed_card_instance_only(99)), "#99");
+    }
+
+    // -- player_display -------------------------------------------------------
+
+    #[test]
+    fn player_display_with_name() {
+        assert_eq!(player_display(&named_player("Alice", 1)), "Alice");
+    }
+
+    #[test]
+    fn player_display_without_name() {
+        assert_eq!(player_display(&anonymous_player(2)), "Player 2");
+    }
+
+    // -- damage_target_display ------------------------------------------------
+
+    #[test]
+    fn damage_target_player() {
+        let target = DamageTarget::Player {
+            player: named_player("Bob", 2),
+        };
+        assert_eq!(damage_target_display(&target), "Bob");
+    }
+
+    #[test]
+    fn damage_target_permanent() {
+        let target = DamageTarget::Permanent {
+            card: named_card("Grizzly Bears"),
+        };
+        assert_eq!(damage_target_display(&target), "Grizzly Bears");
+    }
+
+    // -- action_type_verb -----------------------------------------------------
+
+    #[test]
+    fn action_type_verb_cast_variants() {
+        for variant in [
+            "Cast",
+            "CastAdventure",
+            "CastLeftRoom",
+            "CastRightRoom",
+            "CastLeft",
+            "CastRight",
+            "CastOmen",
+        ] {
+            assert_eq!(action_type_verb(variant), "casts", "failed for {variant}");
+        }
+    }
+
+    #[test]
+    fn action_type_verb_activate() {
+        assert_eq!(action_type_verb("Activate"), "activates");
+    }
+
+    #[test]
+    fn action_type_verb_special() {
+        assert_eq!(action_type_verb("Special"), "uses special ability on");
+        assert_eq!(action_type_verb("SpecialTurnFaceUp"), "uses special ability on");
+    }
+
+    #[test]
+    fn action_type_verb_unknown_defaults_to_plays() {
+        assert_eq!(action_type_verb("SomethingNew"), "plays");
+        assert_eq!(action_type_verb("Play"), "plays");
+    }
+
+    // -- category_contains ----------------------------------------------------
+
+    #[test]
+    fn category_contains_case_insensitive() {
+        assert!(category_contains(Some("CounterSpell"), "counter"));
+        assert!(category_contains(Some("DESTROY"), "destroy"));
+    }
+
+    #[test]
+    fn category_contains_none() {
+        assert!(!category_contains(None, "counter"));
+    }
+
+    // -- zone_transfer_display ------------------------------------------------
+
+    #[test]
+    fn zone_transfer_hand_to_stack_is_cast() {
+        let d = zone_transfer_display(&named_card("Bolt"), "Hand", "Stack", None);
+        assert!(d.description.contains("is cast"));
+        assert_eq!(d.style, ActionStyle::Normal);
+    }
+
+    #[test]
+    fn zone_transfer_library_to_hand_is_drawn() {
+        let d = zone_transfer_display(&named_card("Island"), "Library", "Hand", None);
+        assert!(d.description.contains("drawn"));
+    }
+
+    #[test]
+    fn zone_transfer_stack_to_battlefield_enters() {
+        let d = zone_transfer_display(&named_card("Bear"), "Stack", "Battlefield", None);
+        assert!(d.description.contains("enters the battlefield"));
+    }
+
+    #[test]
+    fn zone_transfer_stack_to_graveyard_countered() {
+        let d = zone_transfer_display(&named_card("Spell"), "Stack", "Graveyard", Some("CounterSpell"));
+        assert!(d.description.contains("is countered"));
+        assert_eq!(d.style, ActionStyle::Negative);
+    }
+
+    #[test]
+    fn zone_transfer_stack_to_graveyard_resolves() {
+        let d = zone_transfer_display(&named_card("Bolt"), "Stack", "Graveyard", None);
+        assert!(d.description.contains("resolves"));
+    }
+
+    #[test]
+    fn zone_transfer_battlefield_to_graveyard_destroyed() {
+        let d = zone_transfer_display(&named_card("Creature"), "Battlefield", "Graveyard", Some("Destroy"));
+        assert!(d.description.contains("is destroyed"));
+    }
+
+    #[test]
+    fn zone_transfer_battlefield_to_graveyard_sacrificed() {
+        let d = zone_transfer_display(&named_card("Token"), "Battlefield", "Graveyard", Some("Sacrifice"));
+        assert!(d.description.contains("is sacrificed"));
+    }
+
+    #[test]
+    fn zone_transfer_battlefield_to_graveyard_dies() {
+        let d = zone_transfer_display(&named_card("Creature"), "Battlefield", "Graveyard", None);
+        assert!(d.description.contains("dies"));
+    }
+
+    #[test]
+    fn zone_transfer_hand_to_graveyard_discarded() {
+        let d = zone_transfer_display(&named_card("Card"), "Hand", "Graveyard", None);
+        assert!(d.description.contains("discarded"));
+    }
+
+    #[test]
+    fn zone_transfer_battlefield_to_hand_bounced() {
+        let d = zone_transfer_display(&named_card("Perm"), "Battlefield", "Hand", None);
+        assert!(d.description.contains("returned to hand"));
+    }
+
+    #[test]
+    fn zone_transfer_battlefield_to_library_tucked() {
+        let d = zone_transfer_display(&named_card("Card"), "Battlefield", "Library", None);
+        assert!(d.description.contains("put on top of library"));
+    }
+
+    #[test]
+    fn zone_transfer_library_to_battlefield_ramp() {
+        let d = zone_transfer_display(&named_card("Land"), "Library", "Battlefield", None);
+        assert!(d.description.contains("enters the battlefield from library"));
+    }
+
+    #[test]
+    fn zone_transfer_library_to_graveyard_milled() {
+        let d = zone_transfer_display(&named_card("Card"), "Library", "Graveyard", None);
+        assert!(d.description.contains("milled"));
+    }
+
+    #[test]
+    fn zone_transfer_graveyard_to_battlefield_recursion() {
+        let d = zone_transfer_display(&named_card("Phoenix"), "Graveyard", "Battlefield", None);
+        assert!(d.description.contains("returns from graveyard"));
+        assert_eq!(d.style, ActionStyle::Positive);
+    }
+
+    #[test]
+    fn zone_transfer_graveyard_to_hand() {
+        let d = zone_transfer_display(&named_card("Card"), "Graveyard", "Hand", None);
+        assert!(d.description.contains("returned to hand from graveyard"));
+        assert_eq!(d.style, ActionStyle::Positive);
+    }
+
+    #[test]
+    fn zone_transfer_exile_to_battlefield() {
+        let d = zone_transfer_display(&named_card("Card"), "Exile", "Battlefield", None);
+        assert!(d.description.contains("enters the battlefield from exile"));
+        assert_eq!(d.style, ActionStyle::Positive);
+    }
+
+    #[test]
+    fn zone_transfer_exile_to_hand() {
+        let d = zone_transfer_display(&named_card("Card"), "Exile", "Hand", None);
+        assert!(d.description.contains("returned to hand from exile"));
+    }
+
+    #[test]
+    fn zone_transfer_anything_to_exile() {
+        let d = zone_transfer_display(&named_card("Creature"), "Battlefield", "Exile", None);
+        assert!(d.description.contains("is exiled"));
+        assert_eq!(d.style, ActionStyle::Negative);
+    }
+
+    #[test]
+    fn zone_transfer_fallback_shows_raw_zones() {
+        let d = zone_transfer_display(&named_card("Card"), "Limbo", "Sideboard", None);
+        assert!(d.description.contains("Limbo"));
+        assert!(d.description.contains("Sideboard"));
+    }
+
+    // -- ActionDisplay::from_game_action --------------------------------------
+
+    #[test]
+    fn from_game_action_new_turn_returns_none() {
+        let action = GameAction::NewTurn {
+            turn_number: 1,
+            active_player: named_player("Alice", 1),
+        };
+        assert!(ActionDisplay::from_game_action(&action, 1).is_none());
+    }
+
+    #[test]
+    fn from_game_action_phase_change() {
+        let action = GameAction::PhaseChange {
+            phase: crate::events::primitives::Phase::Combat,
+            step: Some(crate::events::primitives::Step::DeclareAttack),
+        };
+        let display = ActionDisplay::from_game_action(&action, 1).expect("should produce display");
+        assert_eq!(display.style, ActionStyle::Phase);
+        assert!(display.description.contains("Combat"));
+    }
+
+    #[test]
+    fn from_game_action_card_played_by_controller() {
+        let action = GameAction::CardPlayed {
+            player: named_player("Me", 1),
+            card: named_card("Lightning Bolt"),
+            action_type: "Cast".to_string(),
+        };
+        let display = ActionDisplay::from_game_action(&action, 1).expect("should produce display");
+        assert_eq!(display.style, ActionStyle::PlayerAction);
+        assert!(display.description.contains("casts"));
+        assert!(display.description.contains("Lightning Bolt"));
+    }
+
+    #[test]
+    fn from_game_action_card_played_by_opponent() {
+        let action = GameAction::CardPlayed {
+            player: named_player("Opp", 2),
+            card: named_card("Counterspell"),
+            action_type: "Cast".to_string(),
+        };
+        let display = ActionDisplay::from_game_action(&action, 1).expect("should produce display");
+        assert_eq!(display.style, ActionStyle::OpponentAction);
+    }
+
+    #[test]
+    fn from_game_action_life_gained() {
+        let action = GameAction::LifeChanged {
+            player: named_player("Alice", 1),
+            old_total: 20,
+            new_total: 23,
+            change: 3,
+        };
+        let display = ActionDisplay::from_game_action(&action, 1).expect("should produce display");
+        assert_eq!(display.style, ActionStyle::Positive);
+        assert!(display.description.contains("+3"));
+    }
+
+    #[test]
+    fn from_game_action_life_lost() {
+        let action = GameAction::LifeChanged {
+            player: named_player("Alice", 1),
+            old_total: 20,
+            new_total: 17,
+            change: -3,
+        };
+        let display = ActionDisplay::from_game_action(&action, 1).expect("should produce display");
+        assert_eq!(display.style, ActionStyle::Negative);
+        assert!(display.description.contains("-3"));
+    }
+
+    #[test]
+    fn from_game_action_damage_dealt() {
+        let action = GameAction::DamageDealt {
+            source: named_card("Bolt"),
+            target: DamageTarget::Player {
+                player: named_player("Opp", 2),
+            },
+            amount: 3,
+        };
+        let display = ActionDisplay::from_game_action(&action, 1).expect("should produce display");
+        assert_eq!(display.style, ActionStyle::Damage);
+        assert!(display.description.contains("3 damage"));
+    }
+
+    #[test]
+    fn from_game_action_game_over() {
+        let action = GameAction::GameOver {
+            losing_player: named_player("Opp", 2),
+            reason: Some("life total".to_string()),
+        };
+        let display = ActionDisplay::from_game_action(&action, 1).expect("should produce display");
+        assert_eq!(display.style, ActionStyle::Emphasized);
+        assert!(display.description.contains("loses"));
+        assert!(display.description.contains("life total"));
+    }
+
+    #[test]
+    fn from_game_action_concede() {
+        let action = GameAction::PlayerConceded {
+            player: named_player("Opp", 2),
+        };
+        let display = ActionDisplay::from_game_action(&action, 1).expect("should produce display");
+        assert_eq!(display.style, ActionStyle::Emphasized);
+        assert!(display.description.contains("concedes"));
+    }
+
+    #[test]
+    fn from_game_action_counter_added() {
+        let action = GameAction::CounterAdded {
+            card: named_card("Hydra"),
+            counter_type: Some("+1/+1".to_string()),
+        };
+        let display = ActionDisplay::from_game_action(&action, 1).expect("should produce display");
+        assert_eq!(display.style, ActionStyle::Positive);
+        assert!(display.description.contains("+1/+1 counter"));
+    }
+
+    #[test]
+    fn from_game_action_counter_removed_generic() {
+        let action = GameAction::CounterRemoved {
+            card: named_card("Saga"),
+            counter_type: None,
+        };
+        let display = ActionDisplay::from_game_action(&action, 1).expect("should produce display");
+        assert_eq!(display.style, ActionStyle::Negative);
+        assert!(display.description.contains("counter"));
+    }
+
+    #[test]
+    fn from_game_action_token_created() {
+        let action = GameAction::TokenCreated {
+            card: named_card("Soldier Token"),
+            controller: named_player("Me", 1),
+        };
+        let display = ActionDisplay::from_game_action(&action, 1).expect("should produce display");
+        assert!(display.description.contains("creates token"));
+    }
+}

--- a/core/src/display/match_summary.rs
+++ b/core/src/display/match_summary.rs
@@ -38,3 +38,57 @@ pub fn format_event_id(event_id: &str) -> &str {
         _ => event_id,
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn format_event_id_known_formats() {
+        assert_eq!(format_event_id("Traditional_Ladder"), "Traditional Standard");
+        assert_eq!(format_event_id("Ladder"), "Ranked Standard");
+        assert_eq!(format_event_id("Traditional_Explorer_Ladder"), "Traditional Explorer");
+        assert_eq!(format_event_id("Explorer_Ladder"), "Ranked Explorer");
+        assert_eq!(format_event_id("Traditional_Historic_Ladder"), "Traditional Historic");
+        assert_eq!(format_event_id("Historic_Ladder"), "Ranked Historic");
+        assert_eq!(format_event_id("Traditional_Timeless_Ladder"), "Traditional Timeless");
+        assert_eq!(format_event_id("Timeless_Ladder"), "Ranked Timeless");
+    }
+
+    #[test]
+    fn format_event_id_unknown_passes_through() {
+        assert_eq!(format_event_id("SomeNewFormat_2025"), "SomeNewFormat_2025");
+        assert_eq!(format_event_id(""), "");
+    }
+
+    #[test]
+    fn game_score_formatting() {
+        let summary = MatchSummary {
+            game_wins: 2,
+            game_losses: 1,
+            ..Default::default()
+        };
+        assert_eq!(summary.game_score(), "2-1");
+    }
+
+    #[test]
+    fn game_score_zero() {
+        let summary = MatchSummary::default();
+        assert_eq!(summary.game_score(), "0-0");
+    }
+
+    #[test]
+    fn display_format_uses_format_event_id() {
+        let summary = MatchSummary {
+            format: Some("Traditional_Ladder".to_string()),
+            ..Default::default()
+        };
+        assert_eq!(summary.display_format(), "Traditional Standard");
+    }
+
+    #[test]
+    fn display_format_none_shows_unknown() {
+        let summary = MatchSummary::default();
+        assert_eq!(summary.display_format(), "Unknown");
+    }
+}

--- a/core/src/display/stats.rs
+++ b/core/src/display/stats.rs
@@ -112,3 +112,163 @@ impl OpponentRecord {
         (total > 0).then(|| self.wins as f64 / total as f64 * 100.0)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // -- MatchStats win rates -------------------------------------------------
+
+    #[test]
+    fn match_win_rate_basic() {
+        let stats = MatchStats {
+            match_wins: 7,
+            match_losses: 3,
+            ..Default::default()
+        };
+        let rate = stats.match_win_rate().expect("should have rate");
+        assert!((rate - 70.0).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn match_win_rate_zero_games_returns_none() {
+        let stats = MatchStats::default();
+        assert!(stats.match_win_rate().is_none());
+    }
+
+    #[test]
+    fn game_win_rate_basic() {
+        let stats = MatchStats {
+            game_wins: 3,
+            game_losses: 1,
+            ..Default::default()
+        };
+        let rate = stats.game_win_rate().expect("should have rate");
+        assert!((rate - 75.0).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn game_win_rate_zero_returns_none() {
+        let stats = MatchStats::default();
+        assert!(stats.game_win_rate().is_none());
+    }
+
+    #[test]
+    fn play_win_rate_basic() {
+        let stats = MatchStats {
+            play_wins: 5,
+            play_losses: 5,
+            ..Default::default()
+        };
+        let rate = stats.play_win_rate().expect("should have rate");
+        assert!((rate - 50.0).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn play_win_rate_zero_returns_none() {
+        let stats = MatchStats::default();
+        assert!(stats.play_win_rate().is_none());
+    }
+
+    #[test]
+    fn draw_win_rate_basic() {
+        let stats = MatchStats {
+            draw_wins: 1,
+            draw_losses: 3,
+            ..Default::default()
+        };
+        let rate = stats.draw_win_rate().expect("should have rate");
+        assert!((rate - 25.0).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn draw_win_rate_zero_returns_none() {
+        let stats = MatchStats::default();
+        assert!(stats.draw_win_rate().is_none());
+    }
+
+    #[test]
+    fn win_rate_all_wins() {
+        let stats = MatchStats {
+            match_wins: 10,
+            match_losses: 0,
+            ..Default::default()
+        };
+        let rate = stats.match_win_rate().expect("should have rate");
+        assert!((rate - 100.0).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn win_rate_all_losses() {
+        let stats = MatchStats {
+            match_wins: 0,
+            match_losses: 10,
+            ..Default::default()
+        };
+        let rate = stats.match_win_rate().expect("should have rate");
+        assert!(rate.abs() < f64::EPSILON);
+    }
+
+    // -- MulliganBucket -------------------------------------------------------
+
+    #[test]
+    fn mulligan_bucket_win_rate() {
+        let bucket = MulliganBucket {
+            cards_kept: 7,
+            count: 10,
+            wins: 6,
+            losses: 4,
+        };
+        let rate = bucket.win_rate().expect("should have rate");
+        assert!((rate - 60.0).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn mulligan_bucket_zero_games() {
+        let bucket = MulliganBucket::default();
+        assert!(bucket.win_rate().is_none());
+    }
+
+    // -- OpponentRecord -------------------------------------------------------
+
+    #[test]
+    fn opponent_record_win_rate() {
+        let record = OpponentRecord {
+            name: "Opp".to_string(),
+            matches: 4,
+            wins: 3,
+            losses: 1,
+        };
+        let rate = record.win_rate().expect("should have rate");
+        assert!((rate - 75.0).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn opponent_record_zero_games() {
+        let record = OpponentRecord::default();
+        assert!(record.win_rate().is_none());
+    }
+
+    // -- TimeWindow -----------------------------------------------------------
+
+    #[test]
+    fn time_window_all_time_cutoff_is_none() {
+        assert!(TimeWindow::AllTime.cutoff().is_none());
+    }
+
+    #[test]
+    fn time_window_last_24h_cutoff_is_some() {
+        let cutoff = TimeWindow::Last24Hours.cutoff().expect("should have cutoff");
+        let now = Utc::now();
+        let diff = now - cutoff;
+        assert!((diff.num_hours() - 24).abs() <= 1);
+    }
+
+    #[test]
+    fn time_window_labels() {
+        assert_eq!(TimeWindow::Last24Hours.label(), "Last 24 Hours");
+        assert_eq!(TimeWindow::Last7Days.label(), "Last 7 Days");
+        assert_eq!(TimeWindow::Last30Days.label(), "Last 30 Days");
+        assert_eq!(TimeWindow::AllTime.label(), "All Time");
+    }
+}

--- a/core/src/models/mulligan.rs
+++ b/core/src/models/mulligan.rs
@@ -127,3 +127,129 @@ impl Mulligan {
         serde_json::from_str(&self.hand).unwrap_or_default()
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_mulligan(decision: &str, play_draw: &str, hand: &str) -> Mulligan {
+        Mulligan::new("match_123", 1, 7, hand, play_draw, "UW", decision)
+    }
+
+    #[test]
+    fn did_keep_true() {
+        assert!(make_mulligan("Keep", "Play", "").did_keep());
+    }
+
+    #[test]
+    fn did_keep_case_insensitive() {
+        assert!(make_mulligan("keep", "Play", "").did_keep());
+        assert!(make_mulligan("KEEP", "Play", "").did_keep());
+    }
+
+    #[test]
+    fn did_keep_false_for_mulligan() {
+        assert!(!make_mulligan("Mulligan", "Play", "").did_keep());
+    }
+
+    #[test]
+    fn did_mulligan_true() {
+        assert!(make_mulligan("Mulligan", "Play", "").did_mulligan());
+    }
+
+    #[test]
+    fn did_mulligan_case_insensitive() {
+        assert!(make_mulligan("mulligan", "Play", "").did_mulligan());
+    }
+
+    #[test]
+    fn did_mulligan_false_for_keep() {
+        assert!(!make_mulligan("Keep", "Play", "").did_mulligan());
+    }
+
+    #[test]
+    fn is_on_play() {
+        assert!(make_mulligan("Keep", "Play", "").is_on_play());
+        assert!(make_mulligan("Keep", "play", "").is_on_play());
+    }
+
+    #[test]
+    fn is_on_play_false_for_draw() {
+        assert!(!make_mulligan("Keep", "Draw", "").is_on_play());
+    }
+
+    #[test]
+    fn is_on_draw() {
+        assert!(make_mulligan("Keep", "Draw", "").is_on_draw());
+        assert!(make_mulligan("Keep", "draw", "").is_on_draw());
+    }
+
+    #[test]
+    fn is_on_draw_false_for_play() {
+        assert!(!make_mulligan("Keep", "Play", "").is_on_draw());
+    }
+
+    #[test]
+    fn initial_hand_size_parses_json() {
+        let m = make_mulligan("Keep", "Play", "[1,2,3,4,5,6,7]");
+        assert_eq!(m.initial_hand_size(), 7);
+    }
+
+    #[test]
+    fn initial_hand_size_empty_array() {
+        let m = make_mulligan("Keep", "Play", "[]");
+        assert_eq!(m.initial_hand_size(), 0);
+    }
+
+    #[test]
+    fn initial_hand_size_invalid_json() {
+        let m = make_mulligan("Keep", "Play", "not json");
+        assert_eq!(m.initial_hand_size(), 0);
+    }
+
+    #[test]
+    fn initial_hand_size_csv_format() {
+        let m = make_mulligan("Keep", "Play", "100,200,300");
+        assert_eq!(m.initial_hand_size(), 0);
+    }
+
+    #[test]
+    fn hand_cards_parses_json() {
+        let m = make_mulligan("Keep", "Play", "[10,20,30]");
+        assert_eq!(m.hand_cards(), vec![10, 20, 30]);
+    }
+
+    #[test]
+    fn hand_cards_invalid_returns_empty() {
+        let m = make_mulligan("Keep", "Play", "invalid");
+        assert!(m.hand_cards().is_empty());
+    }
+
+    #[test]
+    fn accessors_return_correct_values() {
+        let m = Mulligan::new("match_1", 2, 6, "hand_str", "Draw", "RG", "Mulligan");
+        assert_eq!(m.match_id(), "match_1");
+        assert_eq!(m.game_number(), 2);
+        assert_eq!(m.number_to_keep(), 6);
+        assert_eq!(m.hand(), "hand_str");
+        assert_eq!(m.play_draw(), "Draw");
+        assert_eq!(m.opponent_identity(), "RG");
+        assert_eq!(m.decision(), "Mulligan");
+    }
+
+    #[test]
+    fn builder_works() {
+        let m = MulliganBuilder::default()
+            .match_id("m1")
+            .game_number(1)
+            .number_to_keep(7)
+            .hand("[1,2,3]")
+            .play_draw("Play")
+            .opponent_identity("UB")
+            .decision("Keep")
+            .build()
+            .expect("builder should succeed");
+        assert_eq!(m.match_id(), "m1");
+        assert!(m.did_keep());
+    }
+}

--- a/core/src/player_log/draft.rs
+++ b/core/src/player_log/draft.rs
@@ -136,3 +136,115 @@ fn parse_event_id(event_id: &str) -> (Format, String) {
 
     (Format::parse_format(parts[0]), parts[1].to_string())
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::models::Format;
+
+    #[test]
+    fn parse_event_id_premier_draft() {
+        let (format, set_code) = parse_event_id("PremierDraft_FDN_20250101");
+        assert_eq!(format, Format::PremierDraft);
+        assert_eq!(set_code, "FDN");
+    }
+
+    #[test]
+    fn parse_event_id_quick_draft() {
+        let (format, set_code) = parse_event_id("QuickDraft_DSK_20241015");
+        assert_eq!(format, Format::QuickDraft);
+        assert_eq!(set_code, "DSK");
+    }
+
+    #[test]
+    fn parse_event_id_traditional_draft() {
+        let (format, set_code) = parse_event_id("TraditionalDraft_MKM_20240301");
+        assert_eq!(format, Format::TraditionalDraft);
+        assert_eq!(set_code, "MKM");
+    }
+
+    #[test]
+    fn parse_event_id_pick_two_draft() {
+        let (format, set_code) = parse_event_id("PickTwoDraft_BLB_20240801");
+        assert_eq!(format, Format::PickTwoDraft);
+        assert_eq!(set_code, "BLB");
+    }
+
+    #[test]
+    fn parse_event_id_too_few_parts() {
+        let (format, set_code) = parse_event_id("PremierDraft_FDN");
+        assert_eq!(format, Format::TraditionalDraft); // default
+        assert_eq!(set_code, "");
+    }
+
+    #[test]
+    fn parse_event_id_too_many_parts() {
+        let (format, set_code) = parse_event_id("a_b_c_d");
+        assert_eq!(format, Format::TraditionalDraft); // default
+        assert_eq!(set_code, "");
+    }
+
+    #[test]
+    fn parse_event_id_empty() {
+        let (format, set_code) = parse_event_id("");
+        assert_eq!(format, Format::TraditionalDraft); // default
+        assert_eq!(set_code, "");
+    }
+
+    #[test]
+    fn parse_event_id_unknown_format() {
+        let (format, set_code) = parse_event_id("CubeDraft_VOW_20220101");
+        assert_eq!(format, Format::Other);
+        assert_eq!(set_code, "VOW");
+    }
+
+    #[test]
+    fn finish_draft_regular_format_needs_pack3_pick13() {
+        let mut builder = DraftBuilder::new();
+        assert!(!builder.finish_draft(Format::PremierDraft));
+
+        let pp = PackPick(3, 13);
+        builder.packs.entry(pp).or_default().push(RawPack {
+            pack_number: 3,
+            pick_number: 13,
+            card_id: ArenaId::new(1),
+            cards: vec![],
+        });
+        assert!(builder.finish_draft(Format::PremierDraft));
+    }
+
+    #[test]
+    fn finish_draft_pick_two_needs_pack3_pick7_twice() {
+        let mut builder = DraftBuilder::new();
+        let pp = PackPick(3, 7);
+
+        builder.packs.entry(pp).or_default().push(RawPack {
+            pack_number: 3,
+            pick_number: 7,
+            card_id: ArenaId::new(1),
+            cards: vec![],
+        });
+        assert!(!builder.finish_draft(Format::PickTwoDraft), "need 2 picks");
+
+        builder.packs.entry(pp).or_default().push(RawPack {
+            pack_number: 3,
+            pick_number: 7,
+            card_id: ArenaId::new(2),
+            cards: vec![],
+        });
+        assert!(builder.finish_draft(Format::PickTwoDraft));
+    }
+
+    #[test]
+    fn finish_draft_wrong_pack_pick_returns_false() {
+        let mut builder = DraftBuilder::new();
+        let pp = PackPick(2, 13);
+        builder.packs.entry(pp).or_default().push(RawPack {
+            pack_number: 2,
+            pick_number: 13,
+            card_id: ArenaId::new(1),
+            cards: vec![],
+        });
+        assert!(!builder.finish_draft(Format::PremierDraft));
+    }
+}

--- a/core/src/player_log/event_log.rs
+++ b/core/src/player_log/event_log.rs
@@ -657,3 +657,509 @@ impl<'a> EventLogBuilder<'a> {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::events::{
+        Event,
+        gre::{
+            GREToClientEvent, GameStateMessage, GameStateMessageWrapper, GreMeta, IntermissionReq,
+            IntermissionReqWrapper, RequestTypeGREToClientEvent,
+        },
+        primitives::{AnnotationDetail, Player, ResultListEntry, Visibility, Zone},
+    };
+
+    fn empty_cards_db() -> CardsDatabase {
+        CardsDatabase::from_bytes(&[]).unwrap_or_default()
+    }
+
+    fn make_player(seat_id: i32, life: i32) -> Player {
+        Player {
+            controller_seat_id: seat_id,
+            controller_type: "ControllerType_Player".to_string(),
+            life_total: life,
+            max_hand_size: 7,
+            starting_life_total: 20,
+            system_seat_number: seat_id,
+            team_id: seat_id,
+            timer_ids: vec![],
+            pending_message_type: None,
+            turn_number: None,
+        }
+    }
+
+    fn make_zone(zone_id: i32, zone_type: ZoneType, owner: Option<i32>) -> Zone {
+        Zone {
+            owner_seat_id: owner,
+            type_field: zone_type,
+            visibility: Visibility::Public,
+            zone_id,
+            viewers: vec![],
+            object_instance_ids: vec![],
+        }
+    }
+
+    fn wrap_gsm(gsm: GameStateMessage) -> Event {
+        Event::GRE(RequestTypeGREToClientEvent {
+            gre_to_client_event: GREToClientEvent {
+                gre_to_client_messages: vec![GREToClientMessage::GameStateMessage(GameStateMessageWrapper {
+                    meta: GreMeta::default(),
+                    game_state_message: gsm,
+                })],
+            },
+            request_id: None,
+            timestamp: String::new(),
+            transaction_id: None,
+        })
+    }
+
+    fn wrap_intermission() -> Event {
+        Event::GRE(RequestTypeGREToClientEvent {
+            gre_to_client_event: GREToClientEvent {
+                gre_to_client_messages: vec![GREToClientMessage::IntermissionReq(IntermissionReqWrapper {
+                    meta: GreMeta::default(),
+                    intermission_req: IntermissionReq {
+                        intermission_prompt: None,
+                        options: vec![],
+                        result: ResultListEntry::default(),
+                    },
+                })],
+            },
+            request_id: None,
+            timestamp: String::new(),
+            transaction_id: None,
+        })
+    }
+
+    fn builder() -> EventLogBuilder<'static> {
+        let cards_db: &'static CardsDatabase = Box::leak(Box::new(empty_cards_db()));
+        let mut names = HashMap::new();
+        names.insert(1, "Player1".to_string());
+        names.insert(2, "Player2".to_string());
+        EventLogBuilder::new(1, cards_db, names)
+    }
+
+    #[test]
+    fn life_change_emits_event() {
+        let events = vec![
+            wrap_gsm(GameStateMessage {
+                game_state_id: 1,
+                players: vec![make_player(1, 20), make_player(2, 20)],
+                update: "Full".to_string(),
+                ..Default::default()
+            }),
+            wrap_gsm(GameStateMessage {
+                game_state_id: 2,
+                players: vec![make_player(1, 17), make_player(2, 20)],
+                update: "Diff".to_string(),
+                ..Default::default()
+            }),
+        ];
+
+        let logs = builder().build(&events);
+        assert_eq!(logs.len(), 1);
+        let life_events: Vec<_> = logs[0]
+            .events
+            .iter()
+            .filter(|e| matches!(&e.action, GameAction::LifeChanged { .. }))
+            .collect();
+        assert_eq!(life_events.len(), 1);
+        match &life_events[0].action {
+            GameAction::LifeChanged {
+                player,
+                old_total,
+                new_total,
+                change,
+            } => {
+                assert_eq!(player.seat_id, 1);
+                assert_eq!(*old_total, 20);
+                assert_eq!(*new_total, 17);
+                assert_eq!(*change, -3);
+            }
+            _ => panic!("expected LifeChanged"),
+        }
+    }
+
+    #[test]
+    fn no_life_change_when_unchanged() {
+        let events = vec![
+            wrap_gsm(GameStateMessage {
+                game_state_id: 1,
+                players: vec![make_player(1, 20)],
+                turn_info: Some(TurnInfo {
+                    turn_number: Some(1),
+                    active_player: Some(1),
+                    phase: Some(Phase::PrecombatMain),
+                    ..Default::default()
+                }),
+                update: "Full".to_string(),
+                ..Default::default()
+            }),
+            wrap_gsm(GameStateMessage {
+                game_state_id: 2,
+                players: vec![make_player(1, 20)],
+                update: "Diff".to_string(),
+                ..Default::default()
+            }),
+        ];
+
+        let logs = builder().build(&events);
+        assert!(!logs.is_empty());
+        let life_events: Vec<_> = logs[0]
+            .events
+            .iter()
+            .filter(|e| matches!(&e.action, GameAction::LifeChanged { .. }))
+            .collect();
+        assert!(life_events.is_empty());
+    }
+
+    #[test]
+    fn turn_info_emits_new_turn_and_phase() {
+        let events = vec![wrap_gsm(GameStateMessage {
+            game_state_id: 1,
+            turn_info: Some(TurnInfo {
+                turn_number: Some(1),
+                active_player: Some(1),
+                phase: Some(Phase::PrecombatMain),
+                step: None,
+                ..Default::default()
+            }),
+            update: "Full".to_string(),
+            ..Default::default()
+        })];
+
+        let logs = builder().build(&events);
+        let new_turns: Vec<_> = logs[0]
+            .events
+            .iter()
+            .filter(|e| matches!(&e.action, GameAction::NewTurn { .. }))
+            .collect();
+        assert_eq!(new_turns.len(), 1);
+
+        let phases: Vec<_> = logs[0]
+            .events
+            .iter()
+            .filter(|e| matches!(&e.action, GameAction::PhaseChange { .. }))
+            .collect();
+        assert_eq!(phases.len(), 1);
+    }
+
+    #[test]
+    fn same_turn_number_does_not_repeat_new_turn() {
+        let events = vec![
+            wrap_gsm(GameStateMessage {
+                game_state_id: 1,
+                turn_info: Some(TurnInfo {
+                    turn_number: Some(1),
+                    active_player: Some(1),
+                    phase: Some(Phase::PrecombatMain),
+                    step: None,
+                    ..Default::default()
+                }),
+                update: "Full".to_string(),
+                ..Default::default()
+            }),
+            wrap_gsm(GameStateMessage {
+                game_state_id: 2,
+                turn_info: Some(TurnInfo {
+                    turn_number: Some(1),
+                    active_player: Some(1),
+                    phase: Some(Phase::Combat),
+                    step: Some(Step::BeginCombat),
+                    ..Default::default()
+                }),
+                update: "Diff".to_string(),
+                ..Default::default()
+            }),
+        ];
+
+        let logs = builder().build(&events);
+        let new_turns: Vec<_> = logs[0]
+            .events
+            .iter()
+            .filter(|e| matches!(&e.action, GameAction::NewTurn { .. }))
+            .collect();
+        assert_eq!(new_turns.len(), 1);
+
+        let phases: Vec<_> = logs[0]
+            .events
+            .iter()
+            .filter(|e| matches!(&e.action, GameAction::PhaseChange { .. }))
+            .collect();
+        assert_eq!(phases.len(), 2);
+    }
+
+    #[test]
+    fn intermission_splits_games() {
+        let events = vec![
+            wrap_gsm(GameStateMessage {
+                game_state_id: 1,
+                players: vec![make_player(1, 20), make_player(2, 20)],
+                turn_info: Some(TurnInfo {
+                    turn_number: Some(1),
+                    active_player: Some(1),
+                    phase: Some(Phase::PrecombatMain),
+                    ..Default::default()
+                }),
+                update: "Full".to_string(),
+                ..Default::default()
+            }),
+            wrap_gsm(GameStateMessage {
+                game_state_id: 2,
+                players: vec![make_player(1, 0), make_player(2, 20)],
+                update: "Diff".to_string(),
+                ..Default::default()
+            }),
+            wrap_intermission(),
+            wrap_gsm(GameStateMessage {
+                game_state_id: 3,
+                players: vec![make_player(1, 20), make_player(2, 20)],
+                turn_info: Some(TurnInfo {
+                    turn_number: Some(1),
+                    active_player: Some(2),
+                    phase: Some(Phase::PrecombatMain),
+                    ..Default::default()
+                }),
+                update: "Full".to_string(),
+                ..Default::default()
+            }),
+        ];
+
+        let logs = builder().build(&events);
+        assert_eq!(logs.len(), 2);
+        assert_eq!(logs[0].game_number, 1);
+        assert_eq!(logs[1].game_number, 2);
+    }
+
+    #[test]
+    fn zone_transfer_annotation_emits_event() {
+        let events = vec![wrap_gsm(GameStateMessage {
+            game_state_id: 1,
+            zones: vec![
+                make_zone(10, ZoneType::Hand, Some(1)),
+                make_zone(20, ZoneType::Graveyard, Some(1)),
+            ],
+            annotations: vec![Annotation {
+                affected_ids: vec![42],
+                affector_id: None,
+                id: 1,
+                type_field: vec![AnnotationType::ZoneTransfer],
+                details: vec![
+                    AnnotationDetail {
+                        key: "zone_src".to_string(),
+                        value_int32: vec![10],
+                        ..Default::default()
+                    },
+                    AnnotationDetail {
+                        key: "zone_dest".to_string(),
+                        value_int32: vec![20],
+                        ..Default::default()
+                    },
+                ],
+            }],
+            update: "Diff".to_string(),
+            ..Default::default()
+        })];
+
+        let logs = builder().build(&events);
+        let transfers: Vec<_> = logs[0]
+            .events
+            .iter()
+            .filter(|e| matches!(&e.action, GameAction::ZoneTransfer { .. }))
+            .collect();
+        assert_eq!(transfers.len(), 1);
+        match &transfers[0].action {
+            GameAction::ZoneTransfer { from_zone, to_zone, .. } => {
+                assert_eq!(from_zone, "Hand");
+                assert_eq!(to_zone, "Graveyard");
+            }
+            _ => panic!("expected ZoneTransfer"),
+        }
+    }
+
+    #[test]
+    fn damage_dealt_annotation_emits_event() {
+        let events = vec![wrap_gsm(GameStateMessage {
+            game_state_id: 1,
+            players: vec![make_player(1, 20), make_player(2, 20)],
+            game_objects: vec![crate::events::gre::GameObject {
+                instance_id: 100,
+                grp_id: Some(ArenaId::new(5000)),
+                owner_seat_id: 1,
+                ..Default::default()
+            }],
+            annotations: vec![Annotation {
+                affected_ids: vec![2],
+                affector_id: Some(100),
+                id: 1,
+                type_field: vec![AnnotationType::DamageDealt],
+                details: vec![AnnotationDetail {
+                    key: "damage".to_string(),
+                    value_int32: vec![3],
+                    ..Default::default()
+                }],
+            }],
+            update: "Diff".to_string(),
+            ..Default::default()
+        })];
+
+        let logs = builder().build(&events);
+        let damage: Vec<_> = logs[0]
+            .events
+            .iter()
+            .filter(|e| matches!(&e.action, GameAction::DamageDealt { .. }))
+            .collect();
+        assert_eq!(damage.len(), 1);
+        match &damage[0].action {
+            GameAction::DamageDealt { amount, target, .. } => {
+                assert_eq!(*amount, 3);
+                assert!(matches!(target, DamageTarget::Player { player } if player.seat_id == 2));
+            }
+            _ => panic!("expected DamageDealt"),
+        }
+    }
+
+    #[test]
+    fn loss_of_game_annotation_emits_game_over() {
+        let events = vec![wrap_gsm(GameStateMessage {
+            game_state_id: 1,
+            annotations: vec![Annotation {
+                affected_ids: vec![2],
+                affector_id: None,
+                id: 1,
+                type_field: vec![AnnotationType::LossOfGame],
+                details: vec![AnnotationDetail {
+                    key: "reason".to_string(),
+                    value_string: vec!["life total".to_string()],
+                    ..Default::default()
+                }],
+            }],
+            update: "Diff".to_string(),
+            ..Default::default()
+        })];
+
+        let logs = builder().build(&events);
+        let game_overs: Vec<_> = logs[0]
+            .events
+            .iter()
+            .filter(|e| matches!(&e.action, GameAction::GameOver { .. }))
+            .collect();
+        assert_eq!(game_overs.len(), 1);
+        match &game_overs[0].action {
+            GameAction::GameOver { losing_player, reason } => {
+                assert_eq!(losing_player.seat_id, 2);
+                assert_eq!(reason.as_deref(), Some("life total"));
+            }
+            _ => panic!("expected GameOver"),
+        }
+    }
+
+    #[test]
+    fn token_created_annotation_emits_event() {
+        let events = vec![wrap_gsm(GameStateMessage {
+            game_state_id: 1,
+            game_objects: vec![crate::events::gre::GameObject {
+                instance_id: 200,
+                grp_id: Some(ArenaId::new(9999)),
+                owner_seat_id: 1,
+                ..Default::default()
+            }],
+            annotations: vec![Annotation {
+                affected_ids: vec![200],
+                affector_id: None,
+                id: 1,
+                type_field: vec![AnnotationType::TokenCreated],
+                details: vec![],
+            }],
+            update: "Diff".to_string(),
+            ..Default::default()
+        })];
+
+        let logs = builder().build(&events);
+        let tokens: Vec<_> = logs[0]
+            .events
+            .iter()
+            .filter(|e| matches!(&e.action, GameAction::TokenCreated { .. }))
+            .collect();
+        assert_eq!(tokens.len(), 1);
+    }
+
+    #[test]
+    fn counter_added_annotation_emits_event() {
+        let events = vec![wrap_gsm(GameStateMessage {
+            game_state_id: 1,
+            game_objects: vec![crate::events::gre::GameObject {
+                instance_id: 300,
+                grp_id: Some(ArenaId::new(7777)),
+                owner_seat_id: 1,
+                ..Default::default()
+            }],
+            annotations: vec![Annotation {
+                affected_ids: vec![300],
+                affector_id: None,
+                id: 1,
+                type_field: vec![AnnotationType::CounterAdded],
+                details: vec![AnnotationDetail {
+                    key: "counterType".to_string(),
+                    value_string: vec!["+1/+1".to_string()],
+                    ..Default::default()
+                }],
+            }],
+            update: "Diff".to_string(),
+            ..Default::default()
+        })];
+
+        let logs = builder().build(&events);
+        let counters: Vec<_> = logs[0]
+            .events
+            .iter()
+            .filter(|e| matches!(&e.action, GameAction::CounterAdded { .. }))
+            .collect();
+        assert_eq!(counters.len(), 1);
+        match &counters[0].action {
+            GameAction::CounterAdded { counter_type, .. } => {
+                assert_eq!(counter_type.as_deref(), Some("+1/+1"));
+            }
+            _ => panic!("expected CounterAdded"),
+        }
+    }
+
+    #[test]
+    fn empty_events_produces_no_game_logs() {
+        let logs = builder().build(&[]);
+        assert!(logs.is_empty());
+    }
+
+    #[test]
+    fn concede_client_message_emits_event() {
+        let events = vec![Event::Client(
+            crate::events::client::RequestTypeClientToMatchServiceMessage {
+                client_to_match_service_message_type: "ClientMessageType_ConcedeReq".to_string(),
+                request_id: 1,
+                payload: crate::events::client::ClientMessage::ConcedeReq(crate::events::client::ConcedeReqWrapper {
+                    meta: crate::events::client::ClientMeta::default(),
+                    concede_req: crate::events::client::ConcedeReq::default(),
+                }),
+                timestamp: None,
+                transaction_id: None,
+            },
+        )];
+
+        let logs = builder().build(&events);
+        assert_eq!(logs.len(), 1);
+        let concedes: Vec<_> = logs[0]
+            .events
+            .iter()
+            .filter(|e| matches!(&e.action, GameAction::PlayerConceded { .. }))
+            .collect();
+        assert_eq!(concedes.len(), 1);
+        match &concedes[0].action {
+            GameAction::PlayerConceded { player } => {
+                assert_eq!(player.seat_id, 1);
+                assert_eq!(player.name.as_deref(), Some("Player1"));
+            }
+            _ => panic!("expected PlayerConceded"),
+        }
+    }
+}

--- a/core/src/player_log/processor.rs
+++ b/core/src/player_log/processor.rs
@@ -38,7 +38,7 @@ impl PlayerLogProcessor {
 
     // try to find the json strings in the logs. ignoring all other info
     // purges whitespace from the internal json strings, but I don't think that will cause
-    // any issues given the log entries I've read
+    // any issues given the log entries seen
     pub fn process_line(&mut self, log_line: &str) -> Vec<String> {
         let mut completed_json_strings = Vec::new();
         log_line.chars().for_each(|char| match char {
@@ -133,5 +133,109 @@ pub fn parse(event: &str) -> Result<ParseOutput> {
         Ok(ParseOutput::DraftNotify(draft_event))
     } else {
         Ok(ParseOutput::NoEvent)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::VecDeque;
+
+    use tokio::{fs::File, io::BufReader};
+
+    use super::*;
+
+    async fn make_processor() -> PlayerLogProcessor {
+        let tmp = std::env::temp_dir().join("arenabuddy_test_empty.log");
+        tokio::fs::write(&tmp, b"").await.expect("write temp file");
+        PlayerLogProcessor {
+            player_log_reader: BufReader::new(File::open(&tmp).await.expect("open temp file")),
+            json_events: VecDeque::new(),
+            current_json_str: None,
+            bracket_depth: 0,
+        }
+    }
+
+    // -- process_line tests ---------------------------------------------------
+
+    #[tokio::test]
+    async fn process_line_extracts_single_json_object() {
+        let mut proc = make_processor().await;
+        let result = proc.process_line(r#"some log prefix {"key":"value"} trailing"#);
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0], r#"{"key":"value"}"#);
+    }
+
+    #[tokio::test]
+    async fn process_line_extracts_multiple_json_objects() {
+        let mut proc = make_processor().await;
+        let result = proc.process_line(r#"{"a":1} noise {"b":2}"#);
+        assert_eq!(result.len(), 2);
+        assert_eq!(result[0], r#"{"a":1}"#);
+        assert_eq!(result[1], r#"{"b":2}"#);
+    }
+
+    #[tokio::test]
+    async fn process_line_handles_nested_braces() {
+        let mut proc = make_processor().await;
+        let result = proc.process_line(r#"{"outer":{"inner":1}}"#);
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0], r#"{"outer":{"inner":1}}"#);
+    }
+
+    #[tokio::test]
+    async fn process_line_strips_whitespace() {
+        let mut proc = make_processor().await;
+        let result = proc.process_line(r#"{ "key" : "value" }"#);
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0], r#"{"key":"value"}"#);
+    }
+
+    #[tokio::test]
+    async fn process_line_spans_multiple_calls() {
+        let mut proc = make_processor().await;
+        let r1 = proc.process_line(r#"prefix {"key":"#);
+        assert!(r1.is_empty(), "incomplete JSON should not produce output");
+
+        let r2 = proc.process_line(r#""value"}"#);
+        assert_eq!(r2.len(), 1);
+        assert_eq!(r2[0], r#"{"key":"value"}"#);
+    }
+
+    #[tokio::test]
+    async fn process_line_no_json() {
+        let mut proc = make_processor().await;
+        let result = proc.process_line("just some plain log text with no braces");
+        assert!(result.is_empty());
+    }
+
+    #[tokio::test]
+    async fn process_line_deeply_nested() {
+        let mut proc = make_processor().await;
+        let input = r#"{"a":{"b":{"c":{"d":1}}}}"#;
+        let result = proc.process_line(input);
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0], input);
+    }
+
+    #[tokio::test]
+    async fn process_line_empty_object() {
+        let mut proc = make_processor().await;
+        let result = proc.process_line("{}");
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0], "{}");
+    }
+
+    // -- parse() dispatch tests -----------------------------------------------
+
+    #[test]
+    fn parse_unrecognized_json_returns_no_event() {
+        let result = parse(r#"{"someRandomField": 42}"#).expect("should not error");
+        assert!(matches!(result, ParseOutput::NoEvent));
+    }
+
+    #[test]
+    fn parse_non_json_returns_no_event() {
+        let result = parse("not json at all");
+        assert!(matches!(result, Ok(ParseOutput::NoEvent)));
     }
 }


### PR DESCRIPTION
Adds unit tests across several core modules to improve coverage of existing logic.

Tests are added for:

- **`display/event_log`** – `card_display`, `player_display`, `damage_target_display`, `action_type_verb`, `category_contains`, `zone_transfer_display` (covering all zone transition combinations), and `ActionDisplay::from_game_action` (covering turn changes, phase changes, card plays, life changes, damage, game over, concede, counters, and token creation).
- **`display/match_summary`** – `format_event_id` for all known ladder formats and unknown pass-through values, `game_score` formatting, and `display_format` with and without a format set.
- **`display/stats`** – Win rate calculations for `MatchStats` (match, game, play, and draw), `MulliganBucket`, and `OpponentRecord`, plus `TimeWindow` cutoff and label behavior.
- **`models/mulligan`** – `did_keep`, `did_mulligan`, `is_on_play`, `is_on_draw`, `initial_hand_size`, `hand_cards`, field accessors, and the `MulliganBuilder`.
- **`player_log/draft`** – `parse_event_id` for all draft formats and edge cases, and `DraftBuilder::finish_draft` for regular, PickTwo, and incorrect pack/pick conditions.
- **`player_log/event_log`** – `EventLogBuilder::build` covering life change detection, turn and phase emission, game splitting on intermission, zone transfer annotations, damage annotations, loss-of-game annotations, token creation, counter additions, concede messages, and empty input.
- **`player_log/processor`** – `process_line` for single and multiple JSON objects, nested braces, whitespace stripping, multi-line spanning, no-JSON input, and empty objects, plus `parse` dispatch for unrecognized and non-JSON input.