### PR TITLE
feat: add decklist Postgres views and Grafana dashboard

### DIFF
--- a/data/migrations/postgres/20260521000000_add_decklist_views.sql
+++ b/data/migrations/postgres/20260521000000_add_decklist_views.sql
@@ -1,0 +1,124 @@
+-- Decklist exploration views for Grafana.
+--
+-- `deck.deck_cards`, `deck.sideboard_cards` and `opponent_deck.cards` are stored
+-- as TEXT containing a flat JSON array of arena IDs, where repeated IDs encode
+-- quantity (e.g. [101,101,101,202] == 3x card 101, 1x card 202).
+--
+-- These views expand those arrays and join the `card` table so dashboards can
+-- query human-readable decklists with a simple WHERE on match + player.
+
+-- One row per individual card copy in the controller's decks, joined to card
+-- metadata. `source` distinguishes main deck vs sideboard.
+CREATE OR REPLACE VIEW deck_card_expanded AS
+SELECT
+    d.match_id,
+    d.game_number,
+    'main'::text AS source,
+    elem.value::bigint AS arena_id,
+    c.name,
+    c.mana_cost,
+    c.cmc,
+    c.type_line,
+    c.layout,
+    c.colors,
+    c.color_identity,
+    c.set_code,
+    c.image_uri
+FROM deck d
+CROSS JOIN LATERAL jsonb_array_elements_text(
+    COALESCE(NULLIF(d.deck_cards, ''), '[]')::jsonb
+) AS elem(value)
+LEFT JOIN card c ON c.arena_id = elem.value::bigint
+UNION ALL
+SELECT
+    d.match_id,
+    d.game_number,
+    'sideboard'::text AS source,
+    elem.value::bigint AS arena_id,
+    c.name,
+    c.mana_cost,
+    c.cmc,
+    c.type_line,
+    c.layout,
+    c.colors,
+    c.color_identity,
+    c.set_code,
+    c.image_uri
+FROM deck d
+CROSS JOIN LATERAL jsonb_array_elements_text(
+    COALESCE(NULLIF(d.sideboard_cards, ''), '[]')::jsonb
+) AS elem(value)
+LEFT JOIN card c ON c.arena_id = elem.value::bigint;
+
+-- One row per individual card copy in the opponent's observed deck.
+CREATE OR REPLACE VIEW opponent_deck_card_expanded AS
+SELECT
+    od.match_id,
+    elem.value::bigint AS arena_id,
+    c.name,
+    c.mana_cost,
+    c.cmc,
+    c.type_line,
+    c.layout,
+    c.colors,
+    c.color_identity,
+    c.set_code,
+    c.image_uri
+FROM opponent_deck od
+CROSS JOIN LATERAL jsonb_array_elements_text(
+    COALESCE(NULLIF(od.cards, ''), '[]')::jsonb
+) AS elem(value)
+LEFT JOIN card c ON c.arena_id = elem.value::bigint;
+
+-- Unified, quantity-aggregated decklist keyed by match_id + player_name.
+-- Combines controller decks (per game, main + sideboard) and the opponent's
+-- observed deck so a Grafana panel only needs WHERE match_id = ... AND
+-- player_name = ...
+CREATE OR REPLACE VIEW match_decklist AS
+SELECT
+    m.id AS match_id,
+    m.controller_player_name AS player_name,
+    'controller'::text AS player_role,
+    dce.game_number,
+    dce.source,
+    dce.arena_id,
+    dce.name,
+    dce.mana_cost,
+    dce.cmc,
+    dce.type_line,
+    dce.layout,
+    dce.colors,
+    dce.color_identity,
+    dce.set_code,
+    dce.image_uri,
+    count(*)::int AS quantity
+FROM match m
+JOIN deck_card_expanded dce ON dce.match_id = m.id
+GROUP BY
+    m.id, m.controller_player_name, dce.game_number, dce.source, dce.arena_id,
+    dce.name, dce.mana_cost, dce.cmc, dce.type_line, dce.layout,
+    dce.colors, dce.color_identity, dce.set_code, dce.image_uri
+UNION ALL
+SELECT
+    m.id AS match_id,
+    m.opponent_player_name AS player_name,
+    'opponent'::text AS player_role,
+    NULL::int AS game_number,
+    'main'::text AS source,
+    oce.arena_id,
+    oce.name,
+    oce.mana_cost,
+    oce.cmc,
+    oce.type_line,
+    oce.layout,
+    oce.colors,
+    oce.color_identity,
+    oce.set_code,
+    oce.image_uri,
+    count(*)::int AS quantity
+FROM match m
+JOIN opponent_deck_card_expanded oce ON oce.match_id = m.id
+GROUP BY
+    m.id, m.opponent_player_name, oce.arena_id,
+    oce.name, oce.mana_cost, oce.cmc, oce.type_line, oce.layout,
+    oce.colors, oce.color_identity, oce.set_code, oce.image_uri;

--- a/server/grafana/provisioning/dashboards/dashboards.yml
+++ b/server/grafana/provisioning/dashboards/dashboards.yml
@@ -1,0 +1,16 @@
+apiVersion: 1
+
+providers:
+  - name: ArenaBuddy
+    orgId: 1
+    folder: ArenaBuddy
+    type: file
+    disableDeletion: false
+    editable: true
+    updateIntervalSeconds: 30
+    allowUiUpdates: true
+    options:
+      # This directory is mounted into the container via the existing
+      # ./grafana/provisioning:/etc/grafana/provisioning bind mount.
+      path: /etc/grafana/provisioning/dashboards
+      foldersFromFilesStructure: false

--- a/server/grafana/provisioning/dashboards/decklists.json
+++ b/server/grafana/provisioning/dashboards/decklists.json
@@ -1,0 +1,161 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": { "type": "grafana", "uid": "-- Grafana --" },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "links": [],
+  "liveNow": false,
+  "panels": [
+    {
+      "datasource": { "type": "postgres", "uid": "arenabuddy_postgres" },
+      "fieldConfig": {
+        "defaults": { "custom": { "align": "auto", "filterable": true }, "mappings": [] },
+        "overrides": [
+          {
+            "matcher": { "id": "byName", "options": "quantity" },
+            "properties": [{ "id": "custom.width", "value": 70 }]
+          },
+          {
+            "matcher": { "id": "byName", "options": "cmc" },
+            "properties": [{ "id": "custom.width", "value": 70 }]
+          }
+        ]
+      },
+      "gridPos": { "h": 18, "w": 16, "x": 0, "y": 0 },
+      "id": 1,
+      "options": {
+        "showHeader": true,
+        "sortBy": [{ "displayName": "cmc", "desc": false }]
+      },
+      "pluginVersion": "10.0.0",
+      "targets": [
+        {
+          "datasource": { "type": "postgres", "uid": "arenabuddy_postgres" },
+          "format": "table",
+          "rawQuery": true,
+          "rawSql": "SELECT\n  source,\n  game_number,\n  quantity,\n  name,\n  mana_cost,\n  cmc,\n  type_line,\n  colors,\n  set_code\nFROM match_decklist\nWHERE match_id = '$match_id'::uuid\n  AND player_name = '$player'\nORDER BY source, cmc, name;",
+          "refId": "A"
+        }
+      ],
+      "title": "Decklist — $player ($match_id)",
+      "type": "table"
+    },
+    {
+      "datasource": { "type": "postgres", "uid": "arenabuddy_postgres" },
+      "fieldConfig": {
+        "defaults": { "color": { "mode": "palette-classic" }, "custom": { "hideFrom": { "legend": false, "tooltip": false, "viz": false } } },
+        "overrides": []
+      },
+      "gridPos": { "h": 9, "w": 8, "x": 16, "y": 0 },
+      "id": 2,
+      "options": {
+        "legend": { "displayMode": "list", "placement": "bottom", "showLegend": true },
+        "pieType": "donut",
+        "reduceOptions": { "calcs": ["sum"], "fields": "", "values": false },
+        "tooltip": { "mode": "single", "sort": "none" }
+      },
+      "pluginVersion": "10.0.0",
+      "targets": [
+        {
+          "datasource": { "type": "postgres", "uid": "arenabuddy_postgres" },
+          "format": "table",
+          "rawQuery": true,
+          "rawSql": "SELECT cmc::text AS \"CMC\", sum(quantity)::int AS value\nFROM match_decklist\nWHERE match_id = '$match_id'::uuid\n  AND player_name = '$player'\n  AND source = 'main'\nGROUP BY cmc\nORDER BY cmc;",
+          "refId": "A"
+        }
+      ],
+      "title": "Mana curve (main, CMC)",
+      "type": "piechart"
+    },
+    {
+      "datasource": { "type": "postgres", "uid": "arenabuddy_postgres" },
+      "fieldConfig": {
+        "defaults": { "color": { "mode": "thresholds" }, "mappings": [], "thresholds": { "mode": "absolute", "steps": [{ "color": "green", "value": null }] } },
+        "overrides": []
+      },
+      "gridPos": { "h": 9, "w": 8, "x": 16, "y": 9 },
+      "id": 3,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "textMode": "value_and_name"
+      },
+      "pluginVersion": "10.0.0",
+      "targets": [
+        {
+          "datasource": { "type": "postgres", "uid": "arenabuddy_postgres" },
+          "format": "table",
+          "rawQuery": true,
+          "rawSql": "SELECT\n  sum(quantity) FILTER (WHERE source = 'main')::int AS \"Main deck\",\n  sum(quantity) FILTER (WHERE source = 'sideboard')::int AS \"Sideboard\",\n  count(DISTINCT arena_id) FILTER (WHERE source = 'main')::int AS \"Unique (main)\"\nFROM match_decklist\nWHERE match_id = '$match_id'::uuid\n  AND player_name = '$player';",
+          "refId": "A"
+        }
+      ],
+      "title": "Counts",
+      "type": "stat"
+    }
+  ],
+  "refresh": "",
+  "schemaVersion": 38,
+  "style": "dark",
+  "tags": ["arenabuddy", "decklists"],
+  "templating": {
+    "list": [
+      {
+        "current": {},
+        "datasource": { "type": "postgres", "uid": "arenabuddy_postgres" },
+        "definition": "SELECT id::text AS __value, controller_player_name || ' vs ' || opponent_player_name || ' (' || left(id::text, 8) || ')' AS __text FROM match ORDER BY created_at DESC NULLS LAST LIMIT 500;",
+        "hide": 0,
+        "includeAll": false,
+        "label": "Match",
+        "multi": false,
+        "name": "match_id",
+        "options": [],
+        "query": "SELECT id::text AS __value, controller_player_name || ' vs ' || opponent_player_name || ' (' || left(id::text, 8) || ')' AS __text FROM match ORDER BY created_at DESC NULLS LAST LIMIT 500;",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 0,
+        "type": "query"
+      },
+      {
+        "current": {},
+        "datasource": { "type": "postgres", "uid": "arenabuddy_postgres" },
+        "definition": "SELECT DISTINCT player_name FROM match_decklist WHERE match_id = '$match_id'::uuid ORDER BY player_name;",
+        "hide": 0,
+        "includeAll": false,
+        "label": "Player",
+        "multi": false,
+        "name": "player",
+        "options": [],
+        "query": "SELECT DISTINCT player_name FROM match_decklist WHERE match_id = '$match_id'::uuid ORDER BY player_name;",
+        "refresh": 2,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 1,
+        "type": "query"
+      }
+    ]
+  },
+  "time": { "from": "now-6h", "to": "now" },
+  "timepicker": {},
+  "timezone": "",
+  "title": "Match Decklists",
+  "uid": "arenabuddy-decklists",
+  "version": 1,
+  "weekStart": ""
+}

--- a/server/grafana/provisioning/datasources/datasources.yml
+++ b/server/grafana/provisioning/datasources/datasources.yml
@@ -24,6 +24,7 @@ datasources:
           url: "$${__value.raw}"
 
   - name: PostgreSQL
+    uid: arenabuddy_postgres
     type: postgres
     access: proxy
     url: postgres:5432

--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -7,7 +7,7 @@ use arenabuddy_core::{
         match_service::match_service_server::MatchServiceServer,
     },
 };
-use arenabuddy_data::{ArenabuddyRepository, MatchDB};
+use arenabuddy_data::{ArenabuddyRepository, CardRepository, MatchDB};
 use tonic::transport::Server;
 use tracing::info;
 
@@ -79,6 +79,8 @@ pub async fn run() -> Result<(), Box<dyn std::error::Error>> {
     db.init().await?;
     info!("Database initialized");
 
+    load_cards_on_startup(&db, &cards).await?;
+
     let spreadsheet_id = std::env::var("GOOGLE_SHEETS_SPREADSHEET_ID").ok();
     if spreadsheet_id.is_some() {
         info!("Google Sheets sync enabled");
@@ -111,5 +113,33 @@ pub async fn run() -> Result<(), Box<dyn std::error::Error>> {
         otel_guard.shutdown();
     }
 
+    Ok(())
+}
+
+/// Populate the `card` table from the embedded cards database.
+///
+/// By default this only loads when the table is empty, so normal restarts are
+/// cheap. Set `ARENABUDDY_RELOAD_CARDS=1` (or `true`) to force a full reload
+/// (TRUNCATE + reinsert) on startup, e.g. after shipping an updated
+/// `cards-full.pb`.
+async fn load_cards_on_startup(db: &MatchDB, cards: &CardsDatabase) -> Result<(), Box<dyn std::error::Error>> {
+    let force_reload =
+        std::env::var("ARENABUDDY_RELOAD_CARDS").is_ok_and(|v| matches!(v.trim(), "1" | "true" | "TRUE" | "yes"));
+
+    let existing = db.card_count().await?;
+    if existing > 0 && !force_reload {
+        info!(
+            "card table already populated ({existing} cards), skipping load (set ARENABUDDY_RELOAD_CARDS=1 to force)"
+        );
+        return Ok(());
+    }
+
+    let to_load: Vec<_> = cards.values().cloned().collect();
+    info!(
+        "Loading {} cards into Postgres (existing: {existing}, force_reload: {force_reload})",
+        to_load.len()
+    );
+    db.load_cards(&to_load).await?;
+    info!("Card load complete");
     Ok(())
 }


### PR DESCRIPTION
Three new PostgreSQL views are added to make decklist data queryable for Grafana dashboards:

- `deck_card_expanded` — unnests the JSON array of arena IDs from a controller's main deck and sideboard into individual rows, joined to card metadata.
- `opponent_deck_card_expanded` — does the same for the opponent's observed deck.
- `match_decklist` — unifies both of the above into a single quantity-aggregated view keyed by `match_id` and `player_name`, allowing Grafana panels to filter with a simple `WHERE match_id = ... AND player_name = ...`.

A new **Match Decklists** Grafana dashboard (`decklists.json`) is provisioned automatically, featuring:
- A sortable, filterable table of the full decklist (main + sideboard) ordered by CMC.
- A donut chart showing the mana curve of the main deck.
- Stat panels showing total main deck count, sideboard count, and unique card count.
- Template variables for selecting a match (displayed as "Controller vs Opponent") and a player, where the player list refreshes based on the selected match.

The PostgreSQL datasource is assigned a stable UID (`arenabuddy_postgres`) so the dashboard JSON can reference it reliably.

On server startup, the `card` table is now populated from the embedded `CardsDatabase`. The load is skipped if the table already contains rows, keeping restarts cheap. Setting `ARENABUDDY_RELOAD_CARDS=1` forces a full reload, which is useful after shipping an updated `cards-full.pb`.