### PR TITLE
refactor: deduplicate bearer token attachment and Scryfall set fetching logic

### DIFF
--- a/arenabuddy/src/app/cards.rs
+++ b/arenabuddy/src/app/cards.rs
@@ -1,5 +1,3 @@
-#![allow(clippy::useless_format)]
-
 use dioxus::prelude::*;
 
 use crate::{

--- a/arenabuddy/src/app/match_details.rs
+++ b/arenabuddy/src/app/match_details.rs
@@ -14,6 +14,7 @@ pub(crate) fn MatchDetails(id: String) -> Element {
     let auth_state = use_context::<SharedAuthState>();
     let mut sync_loading = use_signal(|| false);
     let mut sync_status = use_signal(|| None::<String>);
+    let mut active_tab = use_signal(|| 0u8);
 
     let mut match_details = use_resource({
         let service = service.clone();
@@ -164,7 +165,6 @@ pub(crate) fn MatchDetails(id: String) -> Element {
                 },
 
                 Some(Ok(details)) => {
-                    let mut active_tab = use_signal(|| 0u8);
                     let event_count: usize = details.event_logs.iter().map(|l| l.events.len()).sum();
 
                     let controller_archetype = details.controller_archetype.clone();

--- a/arenabuddy/src/backend/auth.rs
+++ b/arenabuddy/src/backend/auth.rs
@@ -9,6 +9,17 @@ use sha2::{Digest, Sha256};
 use tokio::sync::Mutex;
 use tracing::{error, info};
 
+/// Attach a `Bearer` authorization header to a gRPC request when a token is present.
+///
+/// A no-op if `token` is `None` or the value can't be parsed into a metadata value.
+pub(crate) fn attach_bearer<T>(request: &mut tonic::Request<T>, token: Option<&str>) {
+    if let Some(token) = token
+        && let Ok(value) = format!("Bearer {token}").parse()
+    {
+        request.metadata_mut().insert("authorization", value);
+    }
+}
+
 /// Stored authentication state for the current session.
 #[derive(Debug, Clone)]
 pub struct AuthState {

--- a/arenabuddy/src/backend/grpc_writer.rs
+++ b/arenabuddy/src/backend/grpc_writer.rs
@@ -91,7 +91,7 @@ impl GrpcReplayWriter {
 
         let mut attempt: u32 = 0;
         while attempt < MAX_ATTEMPTS {
-            let request = build_request(match_data, token.clone());
+            let request = build_request(match_data, token.as_deref());
             match self.client.upsert_match_data(request).await {
                 Ok(_) => return Ok(UpsertWithRetries::Success),
                 Err(e) if e.code() == tonic::Code::Unauthenticated => {
@@ -166,12 +166,7 @@ impl GrpcReplayWriter {
             match_id: match_id.to_string(),
         });
 
-        if let Some(token) = token {
-            let bearer = format!("Bearer {token}");
-            if let Ok(value) = bearer.parse() {
-                request.metadata_mut().insert("authorization", value);
-            }
-        }
+        super::auth::attach_bearer(&mut request, token.as_deref());
 
         match self.client.classify_match(request).await {
             Ok(response) => {
@@ -267,17 +262,12 @@ impl arenabuddy_core::player_log::ingest::ReplayWriter for GrpcReplayWriter {
     }
 }
 
-fn build_request(match_data: &MatchData, token: Option<String>) -> tonic::Request<UpsertMatchDataRequest> {
+fn build_request(match_data: &MatchData, token: Option<&str>) -> tonic::Request<UpsertMatchDataRequest> {
     let mut request = tonic::Request::new(UpsertMatchDataRequest {
         match_data: Some(match_data.into()),
     });
 
-    if let Some(token) = token {
-        let bearer = format!("Bearer {token}");
-        if let Ok(value) = bearer.parse() {
-            request.metadata_mut().insert("authorization", value);
-        }
-    }
+    super::auth::attach_bearer(&mut request, token);
 
     request
 }

--- a/arenabuddy/src/backend/ingest.rs
+++ b/arenabuddy/src/backend/ingest.rs
@@ -84,12 +84,7 @@ impl DebugReporter {
         });
 
         let token = self.auth_state.lock().await.as_ref().map(|s| s.token.clone());
-        if let Some(token) = &token {
-            let bearer = format!("Bearer {token}");
-            if let Ok(value) = bearer.parse() {
-                request.metadata_mut().insert("authorization", value);
-            }
-        }
+        super::auth::attach_bearer(&mut request, token.as_deref());
 
         if let Err(e) = self.client.report_parse_errors(request).await {
             error!("Failed to report parse error to server: {e}");

--- a/arenabuddy/src/backend/service.rs
+++ b/arenabuddy/src/backend/service.rs
@@ -142,7 +142,7 @@ where
     pub async fn get_match_details(&self, id: String) -> Result<MatchDetails> {
         info!("looking for match {id}");
 
-        let (mtga_match, result) = self.db.get_match(&id, None).await.unwrap_or_default();
+        let (mtga_match, result) = self.db.get_match(&id, None).await?;
 
         let mut match_details = MatchDetails {
             id: id.clone(),

--- a/arenabuddy/src/backend/sync.rs
+++ b/arenabuddy/src/backend/sync.rs
@@ -9,14 +9,7 @@ use arenabuddy_core::{
 use arenabuddy_data::{ArenabuddyRepository, MatchDB};
 use tracing::{error, info};
 
-use super::auth::{SharedAuthState, needs_refresh, refresh};
-
-fn attach_token<T>(request: &mut tonic::Request<T>, token: &str) {
-    let bearer = format!("Bearer {token}");
-    if let Ok(value) = bearer.parse() {
-        request.metadata_mut().insert("authorization", value);
-    }
-}
+use super::auth::{SharedAuthState, attach_bearer, needs_refresh, refresh};
 
 async fn current_token(auth_state: &SharedAuthState, grpc_url: &str) -> Option<String> {
     let mut guard = auth_state.lock().await;
@@ -62,7 +55,7 @@ pub async fn sync_matches(
 
     // Get server match list
     let mut request = tonic::Request::new(ListMatchesRequest {});
-    attach_token(&mut request, &token);
+    attach_bearer(&mut request, Some(&token));
 
     let server_matches = client.list_matches(request).await?.into_inner().matches;
     info!("Server has {} matches for this user", server_matches.len());
@@ -94,7 +87,7 @@ pub async fn sync_matches(
         let mut request = tonic::Request::new(GetMatchDataRequest {
             match_id: server_match.id.clone(),
         });
-        attach_token(&mut request, &token);
+        attach_bearer(&mut request, Some(&token));
 
         let response = match client.get_match_data(request).await {
             Ok(r) => r.into_inner(),
@@ -179,7 +172,7 @@ pub async fn push_match(
     let mut request = tonic::Request::new(UpsertMatchDataRequest {
         match_data: Some((&match_data).into()),
     });
-    attach_token(&mut request, &token);
+    attach_bearer(&mut request, Some(&token));
 
     let mut client = MatchServiceClient::connect(grpc_url).await?;
     client.upsert_match_data(request).await?;

--- a/cli/src/commands/metagame.rs
+++ b/cli/src/commands/metagame.rs
@@ -3,7 +3,7 @@ use std::path::Path;
 use anyhow::Context;
 use arenabuddy_core::cards::CardsDatabase;
 use arenabuddy_data::{ArenabuddyRepository, MatchDB, MetagameRepository};
-use tracing::info;
+use tracing::{info, warn};
 
 use super::definitions::MetagameCommands;
 use crate::Result;
@@ -15,9 +15,16 @@ async fn connect(db_url: &str, cards: CardsDatabase) -> Result<MatchDB> {
 }
 
 fn load_cards(cards_db: Option<&Path>) -> CardsDatabase {
-    cards_db
-        .and_then(|path| CardsDatabase::new(path).ok())
-        .unwrap_or_default()
+    let Some(path) = cards_db else {
+        return CardsDatabase::default();
+    };
+    CardsDatabase::new(path).unwrap_or_else(|e| {
+        warn!(
+            "Failed to load cards database from {}: {e}; using empty database",
+            path.display()
+        );
+        CardsDatabase::default()
+    })
 }
 
 pub async fn execute(command: &MetagameCommands) -> Result<()> {

--- a/cli/src/commands/parse.rs
+++ b/cli/src/commands/parse.rs
@@ -17,19 +17,15 @@ pub async fn execute(
     cards_db_path: Option<&PathBuf>,
     follow: bool,
 ) -> Result<()> {
-    // Load cards database
     let default_cards_db = PathBuf::from("data/cards-full.pb");
     let cards_db = CardsDatabase::new(cards_db_path.unwrap_or(&default_cards_db))?;
 
-    // Configure the ingestion service
     let config = IngestionConfig::new(player_log.to_path_buf())
         .with_follow(follow)
         .with_rotation_watch(false); // CLI doesn't need rotation watching
 
-    // Create the service
     let mut service = LogIngestionService::new(config).await?.with_shutdown();
 
-    // Add directory storage if specified
     if let Some(output_dir) = output_dir {
         std::fs::create_dir_all(output_dir)?;
         info!("Writing replays to directory: {:?}", output_dir);
@@ -37,7 +33,6 @@ pub async fn execute(
         service = service.add_writer(Box::new(storage));
     }
 
-    // Add database storage if specified
     if let Some(db_url) = db {
         info!("Writing replays to database: {}", db_url);
         let db = MatchDB::new(Some(db_url), cards_db).await?;
@@ -45,7 +40,6 @@ pub async fn execute(
         service = service.add_writer(Box::new(db));
     }
 
-    // Start processing
     info!("Starting log processing from: {:?}", player_log);
     if follow {
         info!("Following log file for new events (press Ctrl+C to stop)");

--- a/cli/src/commands/scrape.rs
+++ b/cli/src/commands/scrape.rs
@@ -5,12 +5,10 @@ use std::{
 };
 
 use arenabuddy_core::models::{Card, CardCollection};
-use reqwest::StatusCode;
 use tracing::{debug, info};
 
+use super::scryfall::USER_AGENT;
 use crate::{Error, Result, errors::ParseError};
-
-const USER_AGENT: &str = "arenabuddy/1.0";
 
 /// Execute the Scrape command
 pub async fn execute(scryfall_host: &str, seventeen_lands_host: &str, output: &Path) -> Result<()> {
@@ -62,7 +60,7 @@ async fn find_sets(base_url: &str, client: &reqwest::Client) -> Result<Vec<Strin
             .iter()
             .filter_map(|set| {
                 if set["set_type"].as_str().is_some_and(|st| st != "token") {
-                    Some(set["code"].as_str().unwrap().to_owned())
+                    set["code"].as_str().map(ToOwned::to_owned)
                 } else {
                     None
                 }
@@ -78,34 +76,9 @@ async fn extract_set(
     set: &str,
 ) -> Result<HashMap<String, serde_json::Value>, Error> {
     debug!("Extracting set: {set}");
-    let set_query = format!("e:{set}");
-    let query = vec![
-        ("include_variations", "true"),
-        ("order", "set"),
-        ("q", &set_query),
-        ("unique", "cards"),
-    ];
-    let response = client
-        .get(format!("{base_url}/cards/search"))
-        .query(&query)
-        .send()
-        .await?;
-    if response.status() == StatusCode::NOT_FOUND {
-        debug!("Extracted {set} returned 404");
-        return Ok(HashMap::new());
-    }
-    response.error_for_status_ref()?;
-    let mut data: serde_json::Value = response.json().await?;
-    let mut ret = HashMap::new();
-    extract_set_cards(&mut ret, &data);
-    super::scryfall::paginate(
-        client,
-        &mut data,
-        &mut ret,
-        Duration::from_millis(150),
-        extract_set_cards,
-    )
-    .await?;
+    let ret = super::scryfall::fetch_set(client, base_url, set, Duration::from_millis(150), extract_set_cards)
+        .await?
+        .unwrap_or_default();
     debug!("Extracted {} cards from {set}", ret.len());
     Ok(ret)
 }
@@ -135,7 +108,7 @@ fn extract_set_cards(set_cards: &mut HashMap<String, serde_json::Value>, data: &
 
 /// Scrape card data from 17Lands
 async fn scrape_seventeen_lands(base_url: &str) -> Result<Vec<HashMap<String, String>>> {
-    let client = reqwest::Client::builder().user_agent("arenabuddy/1.0").build()?;
+    let client = reqwest::Client::builder().user_agent(USER_AGENT).build()?;
     let url = format!("{base_url}/analysis_data/cards/cards.csv");
 
     let response = client.get(&url).send().await?;

--- a/cli/src/commands/scrape_mtga.rs
+++ b/cli/src/commands/scrape_mtga.rs
@@ -10,9 +10,9 @@ use reqwest::StatusCode;
 use rusqlite::Connection;
 use tracing::{debug, info, warn};
 
+use super::scryfall::USER_AGENT;
 use crate::{Error, Result};
 
-const USER_AGENT: &str = "arenabuddy/1.0";
 const SCRYFALL_RATE_LIMIT_MS: u64 = 150;
 
 // Canonical Arena IDs for basic lands (used as fallback when not found in Scryfall)
@@ -42,19 +42,15 @@ struct MtgaCard {
 pub async fn execute(mtga_path: Option<&PathBuf>, scryfall_host: &str, output: &Path) -> Result<()> {
     info!("Starting MTGA database scrape...");
 
-    // 1. Find MTGA database
     let db_path = find_mtga_database(mtga_path)?;
     info!("Found MTGA database at: {}", db_path.display());
 
-    // 2. Extract cards from MTGA database
     let mtga_cards = extract_mtga_cards(&db_path)?;
     info!("Extracted {} cards from MTGA database", mtga_cards.len());
 
-    // 3. Enrich with Scryfall data
     let cards = enrich_with_scryfall(mtga_cards, scryfall_host).await?;
     info!("Successfully enriched {} cards with Scryfall data", cards.len());
 
-    // 4. Save to protobuf
     let collection = CardCollection::with_cards(cards);
     save_card_collection(collection, output).await?;
     info!("Saved card collection to: {}", output.display());
@@ -265,7 +261,7 @@ async fn enrich_with_scryfall(mtga_cards: Vec<MtgaCard>, scryfall_host: &str) ->
                 if let Some(json) = card_json {
                     let mut card = Card::from_json(&json);
                     card.id = mtga_card.grp_id;
-                    card.set = mtga_card.expansion_code.clone();
+                    card.set.clone_from(&mtga_card.expansion_code);
                     cards.push(card);
                     cards_by_id.insert(mtga_card.grp_id);
                 } else if get_basic_land_fallback_id(&mtga_card.name).is_some() {
@@ -337,46 +333,15 @@ async fn fetch_scryfall_set(
     set: &str,
 ) -> Result<Option<HashMap<String, serde_json::Value>>> {
     debug!("Fetching set from Scryfall: {}", set);
-
-    let set_query = format!("e:{set}");
-    let query = vec![
-        ("include_variations", "true"),
-        ("order", "set"),
-        ("q", &set_query),
-        ("unique", "cards"),
-    ];
-
-    let response = client
-        .get(format!("{scryfall_host}/cards/search"))
-        .query(&query)
-        .send()
-        .await?;
-
-    if response.status() == StatusCode::NOT_FOUND {
-        debug!("Set '{}' returned 404 from Scryfall", set);
-        return Ok(None);
-    }
-
-    response.error_for_status_ref()?;
-    let mut data: serde_json::Value = response.json().await?;
-    let mut cards_by_collector_number = HashMap::new();
-
-    // Extract cards from first page
-    extract_set_cards(&mut cards_by_collector_number, &data);
-
-    // Handle pagination
-    super::scryfall::paginate(
+    let cards = super::scryfall::fetch_set(
         client,
-        &mut data,
-        &mut cards_by_collector_number,
+        scryfall_host,
+        set,
         Duration::from_millis(SCRYFALL_RATE_LIMIT_MS),
         extract_set_cards,
     )
     .await?;
-
-    debug!("Fetched {} cards for set {}", cards_by_collector_number.len(), set);
-
-    Ok(Some(cards_by_collector_number))
+    Ok(cards)
 }
 
 /// Extract cards from Scryfall response and index by collector number

--- a/cli/src/commands/scryfall.rs
+++ b/cli/src/commands/scryfall.rs
@@ -1,5 +1,51 @@
 use std::{collections::HashMap, time::Duration};
 
+use reqwest::StatusCode;
+
+/// User agent sent with all Scryfall requests.
+pub const USER_AGENT: &str = "arenabuddy/1.0";
+
+/// Fetch every card in a Scryfall set, indexing each page via `extract`.
+///
+/// Returns `Ok(None)` when the set search returns 404 (unknown set); otherwise
+/// the accumulated map across all pages. `rate_limit` is the delay between page
+/// requests.
+pub async fn fetch_set<F>(
+    client: &reqwest::Client,
+    base_url: &str,
+    set: &str,
+    rate_limit: Duration,
+    extract: F,
+) -> anyhow::Result<Option<HashMap<String, serde_json::Value>>>
+where
+    F: Fn(&mut HashMap<String, serde_json::Value>, &serde_json::Value),
+{
+    let set_query = format!("e:{set}");
+    let query = [
+        ("include_variations", "true"),
+        ("order", "set"),
+        ("q", set_query.as_str()),
+        ("unique", "cards"),
+    ];
+
+    let response = client
+        .get(format!("{base_url}/cards/search"))
+        .query(&query)
+        .send()
+        .await?;
+
+    if response.status() == StatusCode::NOT_FOUND {
+        return Ok(None);
+    }
+    response.error_for_status_ref()?;
+
+    let mut data: serde_json::Value = response.json().await?;
+    let mut results = HashMap::new();
+    extract(&mut results, &data);
+    paginate(client, &mut data, &mut results, rate_limit, extract).await?;
+    Ok(Some(results))
+}
+
 /// Paginate through Scryfall search results, calling `extract` on each page.
 ///
 /// `data` is the JSON response from the initial request. This function follows

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -1,4 +1,3 @@
-#![expect(clippy::assigning_clones)]
 use clap::Parser;
 
 mod commands;

--- a/core/src/models/card.rs
+++ b/core/src/models/card.rs
@@ -336,50 +336,39 @@ impl PartialOrd<Self> for Card {
 
 impl Display for Card {
     fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
-        // First write the card name and set
         write!(f, "{} ({})", self.name, self.set)?;
 
-        // Add mana cost if available
         if !self.mana_cost.is_empty() {
             write!(f, " {}", self.mana_cost)?;
         }
 
-        // Add type line if available
         if !self.type_line.is_empty() {
             write!(f, " - {}", self.type_line)?;
         }
-        // Write the ID
         write!(f, "\nID: {}", self.id)?;
 
-        // Write language if present
         if !self.lang.is_empty() {
             write!(f, "\nLanguage: {}", self.lang)?;
         }
 
-        // Write image URI if present
         if !self.image_uri.is_empty() {
             write!(f, "\nImage URI: {}", self.image_uri)?;
         }
 
-        // Write converted mana cost
         write!(f, "\nMana Value: {}", self.cmc)?;
 
-        // Write layout if present
         if !self.layout.is_empty() {
             write!(f, "\nLayout: {}", self.layout)?;
         }
 
-        // Write colors if present
         if !self.colors.is_empty() {
             write!(f, "\nColors: {}", self.colors.join(", "))?;
         }
 
-        // Write color identity if present
         if !self.color_identity.is_empty() {
             write!(f, "\nColor Identity: {}", self.color_identity.join(", "))?;
         }
 
-        // Write card faces if present
         if !self.card_faces.is_empty() {
             write!(f, "\nCard Faces:")?;
             for (i, face) in self.card_faces.iter().enumerate() {

--- a/core/src/models/deck.rs
+++ b/core/src/models/deck.rs
@@ -1,6 +1,5 @@
 use std::{collections::HashMap, fmt::Display};
 
-use itertools::Itertools;
 use serde_json::Value;
 
 use crate::events::gre::DeckMessage;
@@ -15,16 +14,11 @@ pub struct Quantities(HashMap<i32, usize>);
 
 impl Quantities {
     pub fn from_cards(deck: &[i32]) -> Self {
-        let unique: Vec<_> = deck.iter().unique().copied().collect();
-        let deck_quantities = unique
-            .iter()
-            .map(|ent_id| {
-                let quantity = deck.iter().filter(|&id| id == ent_id).count();
-                (*ent_id, quantity)
-            })
-            .collect();
-
-        Quantities(deck_quantities)
+        let mut quantities = HashMap::new();
+        for &id in deck {
+            *quantities.entry(id).or_insert(0) += 1;
+        }
+        Quantities(quantities)
     }
 
     pub fn get(&self, card_id: i32) -> Option<usize> {

--- a/core/src/player_log/replay.rs
+++ b/core/src/player_log/replay.rs
@@ -68,9 +68,6 @@ impl MatchReplay {
         })
     }
 
-    /// # Errors
-    ///
-    /// Returns an error if the controller seat ID is not found
     pub fn get_controller_seat_id(&self) -> i32 {
         self.controller_seat_id
     }
@@ -102,9 +99,6 @@ impl MatchReplay {
             .collect()
     }
 
-    /// # Errors
-    ///
-    /// Returns an error if the controller seat id is not found
     fn get_opponent_color_identity(&self, cards_db: &CardsDatabase) -> String {
         let opponent_cards = self.get_opponent_cards();
         let mut color_identity = BTreeSet::new();
@@ -493,7 +487,6 @@ impl MatchReplayBuilder {
     /// # Errors
     ///
     /// Returns an error if the builder is missing key information
-    /// except it doesn't right now, so don't worry about it
     fn build_replay(&self) -> Result<MatchReplay> {
         let match_id = self.match_id.clone().ok_or(MatchReplayBuilderError::MissingMatchId)?;
         let match_start_message = self

--- a/core/src/proto/convert.rs
+++ b/core/src/proto/convert.rs
@@ -122,7 +122,10 @@ impl From<&OpponentDeck> for OpponentDeckProto {
 
 impl From<&GameEventLogProto> for GameEventLogDomain {
     fn from(proto: &GameEventLogProto) -> Self {
-        let events = serde_json::from_str(&proto.events_json).unwrap_or_default();
+        let events = serde_json::from_str(&proto.events_json).unwrap_or_else(|e| {
+            tracing::warn!("Failed to parse events_json for game {}: {e}", proto.game_number);
+            Vec::new()
+        });
         Self {
             game_number: proto.game_number,
             events,

--- a/data/src/db/card_postgres.rs
+++ b/data/src/db/card_postgres.rs
@@ -1,6 +1,6 @@
 use arenabuddy_core::models::{Card, CardFace};
 use sqlx::FromRow;
-use tracing::info;
+use tracing::{info, warn};
 
 use super::{card_repository::CardRepository, postgres::PostgresMatchDB};
 use crate::Result;
@@ -23,9 +23,18 @@ struct CardRow {
 
 impl CardRow {
     fn into_card(self) -> Card {
-        let colors: Vec<String> = serde_json::from_str(&self.colors).unwrap_or_default();
-        let color_identity: Vec<String> = serde_json::from_str(&self.color_identity).unwrap_or_default();
-        let card_faces: Vec<CardFaceJson> = serde_json::from_str(&self.card_faces).unwrap_or_default();
+        let colors: Vec<String> = serde_json::from_str(&self.colors).unwrap_or_else(|e| {
+            warn!("Failed to parse colors for card {}: {e}", self.arena_id);
+            Vec::new()
+        });
+        let color_identity: Vec<String> = serde_json::from_str(&self.color_identity).unwrap_or_else(|e| {
+            warn!("Failed to parse color_identity for card {}: {e}", self.arena_id);
+            Vec::new()
+        });
+        let card_faces: Vec<CardFaceJson> = serde_json::from_str(&self.card_faces).unwrap_or_else(|e| {
+            warn!("Failed to parse card_faces for card {}: {e}", self.arena_id);
+            Vec::new()
+        });
 
         Card {
             id: self.arena_id,

--- a/data/src/db/metagame_postgres.rs
+++ b/data/src/db/metagame_postgres.rs
@@ -1,4 +1,5 @@
 use sqlx::{FromRow, types::Uuid};
+use tracing::warn;
 
 use super::{
     metagame_models::{
@@ -285,7 +286,10 @@ impl MetagameRepository for PostgresMatchDB {
         };
 
         // deck_cards is JSON array of arena IDs
-        let arena_ids: Vec<i32> = serde_json::from_str(&row.0).unwrap_or_default();
+        let arena_ids: Vec<i32> = serde_json::from_str(&row.0).unwrap_or_else(|e| {
+            warn!("Failed to parse deck_cards for match {match_id}: {e}");
+            Vec::new()
+        });
         let card_names = self.arena_ids_to_card_names(&arena_ids);
         Ok(card_names)
     }
@@ -301,7 +305,10 @@ impl MetagameRepository for PostgresMatchDB {
             return Ok(Vec::new());
         };
 
-        let arena_ids: Vec<i32> = serde_json::from_str(&row.0).unwrap_or_default();
+        let arena_ids: Vec<i32> = serde_json::from_str(&row.0).unwrap_or_else(|e| {
+            warn!("Failed to parse opponent cards for match {match_id}: {e}");
+            Vec::new()
+        });
         let card_names = self.arena_ids_to_card_names(&arena_ids);
         Ok(card_names)
     }

--- a/data/src/db/postgres.rs
+++ b/data/src/db/postgres.rs
@@ -1,7 +1,6 @@
 #![expect(clippy::cast_possible_truncation)]
 #![expect(clippy::cast_sign_loss)]
 #![expect(clippy::similar_names)]
-#![expect(clippy::field_reassign_with_default)]
 
 use arenabuddy_core::{
     cards::CardsDatabase,
@@ -17,7 +16,7 @@ use arenabuddy_core::{
 use chrono::{DateTime, NaiveDateTime, Utc};
 use postgresql_embedded::PostgreSQL;
 use sqlx::{FromRow, PgPool, Postgres, Transaction, types::Uuid};
-use tracing::{debug, error, info, instrument};
+use tracing::{debug, error, info, instrument, warn};
 
 #[derive(FromRow)]
 struct MatchRow {
@@ -113,15 +112,15 @@ impl PostgresMatchDB {
 
             std::fs::create_dir_all(&db_path)?;
 
-            let mut settings = postgresql_embedded::Settings::default();
-            settings.installation_dir = db_path.join("postgres_install");
-            settings.data_dir = db_path.join("data");
-            settings.password_file = db_path.join("password.txt");
-            settings.temporary = false; // Make database persistent across restarts
-
-            // Use a fixed password for persistent database
-            // This is safe because the embedded DB only listens on localhost
-            settings.password = "arenabuddy_local".to_string();
+            // A fixed password is safe because the embedded DB only listens on localhost.
+            let settings = postgresql_embedded::Settings {
+                installation_dir: db_path.join("postgres_install"),
+                data_dir: db_path.join("data"),
+                password_file: db_path.join("password.txt"),
+                temporary: false, // persist across restarts
+                password: "arenabuddy_local".to_string(),
+                ..Default::default()
+            };
 
             let mut db = PostgreSQL::new(settings);
             db.setup().await?;
@@ -394,7 +393,7 @@ impl PostgresMatchDB {
     pub async fn write_draft(&mut self, draft: &MTGADraft) -> Result<()> {
         info!("Writing draft to database!");
 
-        let mut tx = self.pool.begin().await.map_err(Error::from)?;
+        let mut tx = self.pool.begin().await?;
 
         Self::insert_draft(draft.draft(), &mut tx).await?;
 
@@ -603,7 +602,7 @@ impl ArenabuddyRepository for PostgresMatchDB {
             .format(replay.match_format())
             .build()?;
 
-        let mut tx = self.pool.begin().await.map_err(Error::from)?;
+        let mut tx = self.pool.begin().await?;
 
         Self::insert_match(&match_id, &mtga_match, None, &mut tx).await?;
 
@@ -617,7 +616,6 @@ impl ArenabuddyRepository for PostgresMatchDB {
             Self::insert_mulligan_info(&match_id, mulligan_info, &mut tx).await?;
         }
 
-        // not too keen on this data model
         let match_results = replay.get_match_results()?;
         debug!("{:?}", match_results);
         for (i, result) in match_results.result_list.iter().enumerate() {
@@ -678,8 +676,7 @@ impl ArenabuddyRepository for PostgresMatchDB {
                         .unwrap_or_default(),
                 )
                 .format(row.format)
-                .build()
-                .expect("all fields provided");
+                .build()?;
             Ok((
                 mtga_match,
                 Some(MatchResult::new_match_result(row.id, row.winning_team_id)),
@@ -714,9 +711,8 @@ impl ArenabuddyRepository for PostgresMatchDB {
                     )
                     .format(row.format)
                     .build()
-                    .expect("all fields provided")
             })
-            .collect();
+            .collect::<std::result::Result<_, _>>()?;
 
         info!("found {} matches", matches.len());
         Ok(matches)
@@ -896,7 +892,6 @@ impl ArenabuddyRepository for PostgresMatchDB {
     async fn get_draft(&self, draft_id: &str) -> Result<MTGADraft> {
         let draft_id = Uuid::parse_str(draft_id)?;
 
-        // Get the draft details
         let draft_row = sqlx::query!(
             r#"
             SELECT id, set_code, draft_format, status, created_at
@@ -908,7 +903,6 @@ impl ArenabuddyRepository for PostgresMatchDB {
         .fetch_one(&self.pool)
         .await?;
 
-        // Get all packs for this draft
         let pack_rows = sqlx::query!(
             r#"
             SELECT id, pack_number, pick_number, selection_number, cards, card_id
@@ -921,7 +915,6 @@ impl ArenabuddyRepository for PostgresMatchDB {
         .fetch_all(&self.pool)
         .await?;
 
-        // Construct the Draft model
         let draft = Draft::new(
             draft_row.id,
             draft_row.set_code,
@@ -930,7 +923,6 @@ impl ArenabuddyRepository for PostgresMatchDB {
         )
         .with_created_at(draft_row.created_at.unwrap_or_default().and_utc());
 
-        // Construct the packs
         let mut packs = Vec::new();
         for row in pack_rows {
             let cards: Vec<ArenaId> = serde_json::from_str(&row.cards)?;
@@ -963,7 +955,7 @@ impl ArenabuddyRepository for PostgresMatchDB {
         info!("Upserting match data for match_id: {}", mtga_match.id());
         let match_id = Uuid::parse_str(mtga_match.id())?;
 
-        let mut tx = self.pool.begin().await.map_err(Error::from)?;
+        let mut tx = self.pool.begin().await?;
 
         Self::insert_match(&match_id, mtga_match, user_id, &mut tx).await?;
 
@@ -1002,7 +994,10 @@ impl ArenabuddyRepository for PostgresMatchDB {
         let event_logs = rows
             .into_iter()
             .map(|row| {
-                let events = serde_json::from_str(&row.events_json).unwrap_or_default();
+                let events = serde_json::from_str(&row.events_json).unwrap_or_else(|e| {
+                    warn!("Failed to parse event log for game {}: {e}", row.game_number);
+                    Vec::new()
+                });
                 GameEventLog {
                     game_number: row.game_number,
                     events,

--- a/metagame/src/scraper/tournament.rs
+++ b/metagame/src/scraper/tournament.rs
@@ -48,7 +48,20 @@ pub async fn scrape_single_tournament(
     let decks = parse_tournament_decks(&document, base_url, format);
     info!("  Found {} decks", decks.len());
 
-    for (deck_info, archetype_name) in &decks {
+    import_decks(repo, fetcher, &decks, tournament_db_id, format).await?;
+
+    Ok(())
+}
+
+/// Resolve archetypes and import each deck's cards for a tournament.
+async fn import_decks(
+    repo: &impl MetagameRepository,
+    fetcher: &Fetcher,
+    decks: &[(MetagameDeck, Option<String>)],
+    tournament_db_id: i32,
+    format: &str,
+) -> Result<()> {
+    for (deck_info, archetype_name) in decks {
         let archetype_id = if let Some(name) = archetype_name {
             Some(repo.upsert_metagame_archetype(name, format, None).await?)
         } else {
@@ -116,31 +129,7 @@ pub async fn scrape_tournaments(
             let decks = scrape_tournament_decks(fetcher, base_url, tournament.goldfish_id, format).await?;
             info!("  Found {} decks", decks.len());
 
-            for (deck_info, archetype_name) in &decks {
-                let archetype_id = if let Some(name) = archetype_name {
-                    Some(repo.upsert_metagame_archetype(name, format, None).await?)
-                } else {
-                    None
-                };
-
-                match deck::fetch_deck_cards(fetcher, deck_info.goldfish_id).await {
-                    Ok(cards) => {
-                        let deck_db_id = repo
-                            .upsert_metagame_deck(deck_info, Some(tournament_db_id), archetype_id, &cards)
-                            .await?;
-                        info!(
-                            "    Deck {} ({}): {} cards - db_id={}",
-                            deck_info.goldfish_id,
-                            deck_info.player_name.as_deref().unwrap_or("unknown"),
-                            cards.len(),
-                            deck_db_id,
-                        );
-                    }
-                    Err(e) => {
-                        tracing::warn!("    Failed to fetch deck {}: {e:#}", deck_info.goldfish_id);
-                    }
-                }
-            }
+            import_decks(repo, fetcher, &decks, tournament_db_id, format).await?;
         }
 
         page += 1;

--- a/server/src/match_service.rs
+++ b/server/src/match_service.rs
@@ -9,7 +9,7 @@ use arenabuddy_core::{
 };
 use arenabuddy_data::{ArenabuddyRepository, MatchDB};
 use tonic::{Request, Response, Status};
-use tracing::{error, info, instrument};
+use tracing::{debug, error, info, instrument};
 
 use crate::auth::UserId;
 
@@ -109,6 +109,7 @@ impl MatchService for MatchServiceImpl {
             .db
             .get_opponent_deck(&match_id)
             .await
+            .inspect_err(|e| debug!("No opponent deck for match {match_id}: {e}"))
             .ok()
             .map_or_else(OpponentDeck::empty, |d| {
                 OpponentDeck::new(d.mainboard().iter().map(|&id| ArenaId::from(id)).collect())


### PR DESCRIPTION
Refactor bearer token attachment into a shared `attach_bearer` helper, consolidate duplicated Scryfall set-fetching logic into a reusable `fetch_set` function, and deduplicate the `import_decks` loop in the tournament scraper.

**Bearer token attachment** — The repeated inline pattern of formatting a `Bearer` string and inserting it into gRPC request metadata has been replaced with a single `attach_bearer` function in `backend/auth.rs`. All call sites in `grpc_writer`, `ingest`, and `sync` now use this helper. The `attach_token` local function in `sync.rs` has been removed. `build_request` and related functions now accept `Option<&str>` instead of `Option<String>` to avoid unnecessary cloning.

**Scryfall set fetching** — The duplicated Scryfall card search + pagination logic that existed in both `scrape.rs` and `scrape_mtga.rs` has been extracted into `scryfall::fetch_set`. The `USER_AGENT` constant has also been moved to `scryfall.rs` and is now imported by both scrapers. `fetch_set` returns `Ok(None)` on 404 and the accumulated card map otherwise.

**Tournament deck import** — The `import_decks` loop in `tournament.rs` was duplicated between `scrape_single_tournament` and `scrape_tournaments`. It is now extracted into a private `import_decks` function called from both sites.

**Error handling improvements** — Several `unwrap_or_default` calls on `serde_json` deserialization now use `unwrap_or_else` with a `warn!` log so failures are visible. A `get_match` call in `service.rs` now propagates errors with `?` instead of silently defaulting. `build()` calls that previously panicked with `expect` now propagate errors. The `active_tab` signal in `match_details.rs` has been moved outside the `Some(Ok(...))` match arm to avoid calling a hook conditionally.

**Minor cleanups** — Removed `itertools` from `Quantities::from_cards` in favour of a simple `HashMap` accumulation. Removed stale, inaccurate doc comments. Removed now-unnecessary `#[allow]` and `#[expect]` lint suppression attributes. Removed inline comments that restated the code.