### PR TITLE
chore: bump chrono and uuid dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8353,9 +8353,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.23.1"
+version = "1.23.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddd74a9687298c6858e9b88ec8935ec45d22e8fd5e6394fa1bd4e99a87789c76"
+checksum = "d258b83ceec21034727ecee8c382cfa6c3e133699b0742c64571814fb420c9f7"
 dependencies = [
  "getrandom 0.4.2",
  "js-sys",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ anyhow = "1.0.102"
 async-trait = "0.1"
 axum = "0.8.9"
 base64 = "0.22"
-chrono = { version = "0.4.44", features = ["serde", "wasmbind"] }
+chrono = { version = "0.4.45", features = ["serde", "wasmbind"] }
 clap = { version = "4.6.1", features = ["derive"] }
 console-subscriber = "0.5.0"
 csv = { version = "1.4.0" }
@@ -84,7 +84,7 @@ opentelemetry-otlp = { version = "0.32.0", default-features = false, features = 
     "trace",
 ] }
 urlencoding = "2.1.3"
-uuid = { version = "1.23.1", features = ["v4", "js"] }
+uuid = { version = "1.23.2", features = ["v4", "js"] }
 yup-oauth2 = { version = "12.1.2", features = [
     "hyper-rustls",
     "service-account",


### PR DESCRIPTION
Bumps `uuid` from 1.23.1 to 1.23.2 and `chrono` from 0.4.44 to 0.4.45.