### PR TITLE
chore: bump Rust to 1.96 in Dockerfiles

### DIFF
--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.94-bookworm AS chef
+FROM rust:1.96-bookworm AS chef
 RUN cargo install cargo-chef@0.1.73
 WORKDIR /app
 

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.94-bookworm AS builder
+FROM rust:1.96-bookworm AS builder
 RUN rustup target add wasm32-unknown-unknown
 RUN cargo install dioxus-cli@0.7.3 --locked
 WORKDIR /app


### PR DESCRIPTION
Upgrades the Rust toolchain from version 1.94 to 1.96 in both the server and web Dockerfiles.