### PR TITLE
chore: bump itertools to 0.15.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -182,7 +182,7 @@ dependencies = [
  "chrono",
  "ctrlc",
  "derive_builder",
- "itertools",
+ "itertools 0.15.0",
  "notify",
  "prost",
  "prost-types",
@@ -3876,6 +3876,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "itertools"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b4baf93f58d4425749ca49a51c50ebab072c5df6994d08fed93541c331481dc"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5590,7 +5599,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "343d3bd7056eda839b03204e68deff7d1b13aba7af2b2fd16890697274262ee7"
 dependencies = [
  "heck 0.5.0",
- "itertools",
+ "itertools 0.14.0",
  "log",
  "multimap",
  "petgraph",
@@ -5611,7 +5620,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b570b25f7617e43d59005d0990ccb79e950a423952cea19671b7a876da390adf"
 dependencies = [
  "anyhow",
- "itertools",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -5888,7 +5897,7 @@ dependencies = [
  "built",
  "cfg-if",
  "interpolate_name",
- "itertools",
+ "itertools 0.14.0",
  "libc",
  "libfuzzer-sys",
  "log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ dirs = "6.0.0"
 dioxus = { version = "0.8.0-alpha.0" }
 google-sheets4 = { version = "7.0.0" }
 jsonwebtoken = { version = "10.4.0", features = ["rust_crypto"] }
-itertools = "0.14.0"
+itertools = "0.15.0"
 notify = "8.2.0"
 open = "5.3"
 postgresql_embedded = { version = "0.20.4", features = ["bundled"] }


### PR DESCRIPTION
Upgrades `itertools` from version `0.14.0` to `0.15.0`. Dependencies that require `0.14.0` (`prost-build`, `prost-derive`, and `rav1e`) continue to resolve to that version independently.